### PR TITLE
Add new diagnostics for MapkeyAnnotations: Access Specifier and Type check

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode implements IJavaErrorCode {
     InvalidTypeOfField,
     InvalidMethodName,
     InvalidMethodAccessSpecifier,
-    InvalidReturnTypeOfMethod;
+    InvalidReturnTypeOfMethod,
+    InvalidMapKeyAnnotationsFieldNotFound;
 
     /**
      * {@inheritDoc}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode implements IJavaErrorCode {
     InvalidMethodWithMultipleMPJCAnnotations,
     InvalidFieldWithMultipleMPJCAnnotations,
     InvalidTypeOfField,
+    InvalidMethodName,
+    InvalidMethodAccessSpecifier,
     InvalidReturnTypeOfMethod;
 
     /**

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/ErrorCode.java
@@ -26,9 +26,8 @@ public enum ErrorCode implements IJavaErrorCode {
     InvalidMapKeyAnnotationsOnSameField,
     InvalidMethodWithMultipleMPJCAnnotations,
     InvalidFieldWithMultipleMPJCAnnotations,
-	InvalidTypeOfField,
-	InvalidReturnTypeOfMethod;
-	
+    InvalidTypeOfField,
+    InvalidReturnTypeOfMethod;
 
     /**
      * {@inheritDoc}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/ErrorCode.java
@@ -25,7 +25,10 @@ public enum ErrorCode implements IJavaErrorCode {
     InvalidMapKeyAnnotationsOnSameMethod,
     InvalidMapKeyAnnotationsOnSameField,
     InvalidMethodWithMultipleMPJCAnnotations,
-    InvalidFieldWithMultipleMPJCAnnotations;
+    InvalidFieldWithMultipleMPJCAnnotations,
+	InvalidTypeOfField,
+	InvalidReturnTypeOfMethod;
+	
 
     /**
      * {@inheritDoc}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -146,28 +146,12 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
                 }
             }
 
-            Range range = null;
-            String messageKey = null;
-            ErrorCode errorCode = null;
-            String attribute = null;
-
             if (hasMapKeyAnnotation && hasMapKeyClassAnnotation) {
                 //A single method/field cannot be annotated with both @MapKey and @MapKeyClass
                 //Specification References:
                 //https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkey
                 //https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkeyclass
-
-                if (member instanceof IMethod) {
-                    range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
-                    messageKey = "MapKeyAnnotationsNotOnSameMethod";
-                    errorCode = ErrorCode.InvalidMapKeyAnnotationsOnSameMethod;
-                } else if (member instanceof IField) {
-                    range = PositionUtils.toNameRange((IField) member, context.getUtils());
-                    messageKey = "MapKeyAnnotationsNotOnSameField";
-                    errorCode = ErrorCode.InvalidMapKeyAnnotationsOnSameField;
-                }
-                diagnostics.add(context.createDiagnostic(context.getUri(), Messages.getMessage(messageKey), range,
-                                                         Constants.DIAGNOSTIC_SOURCE, null, errorCode, DiagnosticSeverity.Error));
+            	collectMapKeyAnnotationsDiagnostics(member,context,diagnostics);
 			} else if (hasMapKeyAnnotation) {
 				collectTypeDiagnostics(member, "@MapKey", context, diagnostics);
 			} else if (hasMapKeyClassAnnotation) {
@@ -218,6 +202,33 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
 			diagnostics.add(context.createDiagnostic(context.getUri(), Messages.getMessage(messageKey, attribute), range,
 							Constants.DIAGNOSTIC_SOURCE, null, errorCode, DiagnosticSeverity.Error));
 		}
+	}
+	
+	private void collectMapKeyAnnotationsDiagnostics(IMember member,JavaDiagnosticsContext context,
+			List<Diagnostic> diagnostics) throws CoreException {
+		
+		Range range = null;
+		String messageKey = null;
+		ErrorCode errorCode = null;
+		
+		 if (member instanceof IMethod) {
+			 
+             range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
+             messageKey = "MapKeyAnnotationsNotOnSameMethod";
+             errorCode = ErrorCode.InvalidMapKeyAnnotationsOnSameMethod;
+             
+         } else if (member instanceof IField) {
+        	 
+             range = PositionUtils.toNameRange((IField) member, context.getUtils());
+             messageKey = "MapKeyAnnotationsNotOnSameField";
+             errorCode = ErrorCode.InvalidMapKeyAnnotationsOnSameField;
+             
+         }
+		 
+		 if (messageKey != null) {
+			 diagnostics.add(context.createDiagnostic(context.getUri(), Messages.getMessage(messageKey), range,
+                     Constants.DIAGNOSTIC_SOURCE, null, errorCode, DiagnosticSeverity.Error));
+		 }
 	}
 
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -12,10 +12,7 @@
 *******************************************************************************/
 package org.eclipse.lsp4jakarta.jdt.internal.persistence;
 
-import java.beans.BeanInfo;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.lang.reflect.Field;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -165,6 +165,9 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
                 validateMapKeyJoinColumnAnnotations(context, context.getUri(), mapKeyJoinCols, member, unit,
                                                     diagnostics);
             }
+            
+            //Check method has right access specifier and follows JavaBean accessor conventions
+            collectAccessorDiagnostics(member, context, diagnostics);
         }
     }
 
@@ -238,6 +241,7 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
         ErrorCode errorCode = null;
         
         if (member instanceof IMethod) {
+        	
         	String methodName = member.getElementName();
         	int flag = member.getFlags();
         	
@@ -245,10 +249,19 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
         	boolean isStartsWithGet = methodName.startsWith("get");
         	
         	if(!isPublic) {
-        		
+        		range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
+                messageKey = "MapKeyAnnotationsInvalidMethodAccessSpecifier";
+                errorCode = ErrorCode.InvalidMethodAccessSpecifier;
         	}else if(!isStartsWithGet) {
-        		
+        		range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
+                messageKey = "MapKeyAnnotationsOnInvalidMethod";
+                errorCode = ErrorCode.InvalidMethodName;
         	}
+        	
+        	if (messageKey != null) {
+                diagnostics.add(context.createDiagnostic(context.getUri(), Messages.getMessage(messageKey), range,
+                                                         Constants.DIAGNOSTIC_SOURCE, null, errorCode, DiagnosticSeverity.Warning));
+            }
         }
 	}
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -29,7 +29,6 @@ import org.eclipse.jdt.core.IMemberValuePair;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeHierarchy;
-import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.lsp4j.Diagnostic;
@@ -51,6 +50,7 @@ import org.eclipse.lsp4jakarta.jdt.internal.core.ls.JDTUtilsLSImpl;
 public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnosticsParticipant {
 	
 	private static final Logger LOGGER = Logger.getLogger(PersistenceMapKeyDiagnosticsParticipant.class.getName());
+	final String MAP_INTERFACE_FQDN = "java.util.Map";
 
     /**
      * {@inheritDoc}
@@ -213,7 +213,7 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
         }
        
 		if (fqName != null) {
-			if ("java.util.Map".equals(fqName)) {
+			if (MAP_INTERFACE_FQDN.equals(fqName)) {
 				isMap = true;
 
 			} else {
@@ -223,7 +223,7 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
 				IType[] interfaces = hierarchy.getAllSuperInterfaces(returnType);
 
 				for (IType superInterface : interfaces) {
-					if ("java.util.Map".equals(superInterface.getFullyQualifiedName())) {
+					if (MAP_INTERFACE_FQDN.equals(superInterface.getFullyQualifiedName())) {
 						isMap = true;
 					}
 				}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -163,10 +163,6 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
             }
 
             if (hasMapKeyAnnotation && hasMapKeyClassAnnotation) {
-                // A single method/field cannot be annotated with both @MapKey and @MapKeyClass
-                // Specification References:
-                // https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkey
-                // https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkeyclass
                 collectMapKeyAnnotationsDiagnostics(member, context, diagnostics);
             }
 
@@ -249,6 +245,10 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
         String messageKey = null;
         ErrorCode errorCode = null;
 
+        // A single method/field cannot be annotated with both @MapKey and @MapKeyClass
+        // Specification References:
+        // https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkey
+        // https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkeyclass
         if (member instanceof IMethod) {
             range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
             messageKey = "MapKeyAnnotationsNotOnSameMethod";

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -307,7 +307,7 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
         }
     }
     
-    public boolean hasField(IMethod method) throws JavaModelException {
+    private boolean hasField(IMethod method) throws JavaModelException {
 
         boolean result = false;
         String methodName = method.getElementName();

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -165,7 +165,7 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
                 validateMapKeyJoinColumnAnnotations(context, context.getUri(), mapKeyJoinCols, member, unit,
                                                     diagnostics);
             }
-            
+
             //Check method has right access specifier and follows JavaBean accessor conventions
             collectAccessorDiagnostics(member, context, diagnostics);
         }
@@ -234,34 +234,34 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
         }
     }
 
-	private void collectAccessorDiagnostics(IMember member, JavaDiagnosticsContext context,
-											List<Diagnostic> diagnostics) throws CoreException {
-		Range range = null;
+    private void collectAccessorDiagnostics(IMember member, JavaDiagnosticsContext context,
+                                            List<Diagnostic> diagnostics) throws CoreException {
+        Range range = null;
         String messageKey = null;
         ErrorCode errorCode = null;
-        
+
         if (member instanceof IMethod) {
-        	
-        	String methodName = member.getElementName();
-        	int flag = member.getFlags();
-        	
-        	boolean isPublic  = Flags.isPublic(flag);
-        	boolean isStartsWithGet = methodName.startsWith("get");
-        	
-        	if(!isPublic) {
-        		range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
+
+            String methodName = member.getElementName();
+            int flag = member.getFlags();
+
+            boolean isPublic = Flags.isPublic(flag);
+            boolean isStartsWithGet = methodName.startsWith("get");
+
+            if (!isPublic) {
+                range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
                 messageKey = "MapKeyAnnotationsInvalidMethodAccessSpecifier";
                 errorCode = ErrorCode.InvalidMethodAccessSpecifier;
-        	}else if(!isStartsWithGet) {
-        		range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
+            } else if (!isStartsWithGet) {
+                range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
                 messageKey = "MapKeyAnnotationsOnInvalidMethod";
                 errorCode = ErrorCode.InvalidMethodName;
-        	}
-        	
-        	if (messageKey != null) {
+            }
+
+            if (messageKey != null) {
                 diagnostics.add(context.createDiagnostic(context.getUri(), Messages.getMessage(messageKey), range,
                                                          Constants.DIAGNOSTIC_SOURCE, null, errorCode, DiagnosticSeverity.Warning));
             }
         }
-	}
+    }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -122,7 +122,7 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
 
         List<IAnnotation> mapKeyJoinCols = null;
         boolean hasMapKeyAnnotation = false;
-        boolean hasMapKeyClassAnnotation = false;
+        boolean hasMapKeyClassAnnotation = false, hasTypeDiagnostics = false;
         IAnnotation[] allAnnotations = null;
 
         // Go through each method/field to ensure they do not have both MapKey and MapKeyColumn Annotations
@@ -153,16 +153,16 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
             }
 
             if (hasMapKeyAnnotation) {
-                collectTypeDiagnostics(member, "@MapKey", context, diagnostics);
+                hasTypeDiagnostics = collectTypeDiagnostics(member, "@MapKey", context, diagnostics);
                 collectAccessorDiagnostics(member, context, diagnostics);
             }
 
             if (hasMapKeyClassAnnotation) {
-                collectTypeDiagnostics(member, "@MapKeyClass", context, diagnostics);
+                hasTypeDiagnostics = collectTypeDiagnostics(member, "@MapKeyClass", context, diagnostics);
                 collectAccessorDiagnostics(member, context, diagnostics);
             }
 
-            if (hasMapKeyAnnotation && hasMapKeyClassAnnotation) {
+            if (!hasTypeDiagnostics && (hasMapKeyAnnotation && hasMapKeyClassAnnotation)) {
                 collectMapKeyAnnotationsDiagnostics(member, context, diagnostics);
             }
 
@@ -175,9 +175,10 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
         }
     }
 
-    private void collectTypeDiagnostics(IMember member, String attribute, JavaDiagnosticsContext context,
+    private boolean collectTypeDiagnostics(IMember member, String attribute, JavaDiagnosticsContext context,
             List<Diagnostic> diagnostics) throws CoreException {
 
+        boolean hasTypeDiagnostics = false;
         Range range = null;
         String messageKey = null, typeSignature = null, readableType = null;
         String packageValue = null, typeValue = null, fqName = null;
@@ -233,9 +234,11 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
         }
 
         if (messageKey != null) {
+            hasTypeDiagnostics = true;
             diagnostics.add(context.createDiagnostic(context.getUri(), Messages.getMessage(messageKey, attribute),
                     range, Constants.DIAGNOSTIC_SOURCE, null, errorCode, DiagnosticSeverity.Error));
         }
+        return hasTypeDiagnostics;
     }
 
     private void collectMapKeyAnnotationsDiagnostics(IMember member, JavaDiagnosticsContext context,

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -25,7 +25,9 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMemberValuePair;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Range;
@@ -144,14 +146,17 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
                 }
             }
 
+            Range range = null;
+            String messageKey = null;
+            ErrorCode errorCode = null;
+            String attribute = null;
+
             if (hasMapKeyAnnotation && hasMapKeyClassAnnotation) {
                 //A single method/field cannot be annotated with both @MapKey and @MapKeyClass
                 //Specification References:
                 //https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkey
                 //https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/mapkeyclass
-                Range range = null;
-                String messageKey = null;
-                ErrorCode errorCode = null;
+
                 if (member instanceof IMethod) {
                     range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
                     messageKey = "MapKeyAnnotationsNotOnSameMethod";
@@ -163,7 +168,11 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
                 }
                 diagnostics.add(context.createDiagnostic(context.getUri(), Messages.getMessage(messageKey), range,
                                                          Constants.DIAGNOSTIC_SOURCE, null, errorCode, DiagnosticSeverity.Error));
-            }
+			} else if (hasMapKeyAnnotation) {
+				collectTypeDiagnostics(member, "@MapKey", context, diagnostics);
+			} else if (hasMapKeyClassAnnotation) {
+				collectTypeDiagnostics(member, "@MapKeyClass", context, diagnostics);
+			}
 
             // If we have multiple MapKeyJoinColumn annotations on a single method/field
             // we must ensure each has a name and referencedColumnName
@@ -173,4 +182,42 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
             }
         }
     }
+    
+	private void collectTypeDiagnostics(IMember member, String attribute, JavaDiagnosticsContext context,
+			List<Diagnostic> diagnostics) throws CoreException {
+		
+		Range range = null;
+		String messageKey = null, typeSignature = null, readableType = null;
+		ErrorCode errorCode = null;
+		
+
+		if (member instanceof IMethod) {
+
+			typeSignature = ((IMethod) member).getReturnType();
+			readableType = Signature.toString(typeSignature);
+
+			if (!readableType.toUpperCase().contains("MAP")) {
+				range = PositionUtils.toNameRange((IMethod) member, context.getUtils());
+				messageKey = "MapKeyAnnotationsReturnTypeOfMethod";
+				errorCode = ErrorCode.InvalidReturnTypeOfMethod;
+			}
+
+		} else if (member instanceof IField) {
+			
+			typeSignature = ((IField) member).getTypeSignature();
+			readableType = Signature.toString(Signature.getElementType(typeSignature));
+
+			if (!readableType.toUpperCase().contains("MAP")) {
+				range = PositionUtils.toNameRange((IField) member, context.getUtils());
+				messageKey = "MapKeyAnnotationsTypeOfField";
+				errorCode = ErrorCode.InvalidTypeOfField;
+			}
+
+		}
+		if (messageKey != null) {
+			diagnostics.add(context.createDiagnostic(context.getUri(), Messages.getMessage(messageKey, attribute), range,
+							Constants.DIAGNOSTIC_SOURCE, null, errorCode, DiagnosticSeverity.Error));
+		}
+	}
+
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -151,6 +151,13 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
                     }
                 }
             }
+            
+            String attribute = hasMapKeyAnnotation? "@MapKey" : hasMapKeyClassAnnotation? "@MapKeyClass" : null ;
+            
+            if (hasMapKeyAnnotation || hasMapKeyClassAnnotation) {
+                collectTypeDiagnostics(member, attribute, context, diagnostics);
+                collectAccessorDiagnostics(member, context, diagnostics);
+            }
 
             if (hasMapKeyAnnotation && hasMapKeyClassAnnotation) {
                 //A single method/field cannot be annotated with both @MapKey and @MapKeyClass
@@ -166,17 +173,6 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
                 validateMapKeyJoinColumnAnnotations(context, context.getUri(), mapKeyJoinCols, member, unit,
                                                     diagnostics);
             }
-                
-            if (hasMapKeyAnnotation) {
-                collectTypeDiagnostics(member, "@MapKey", context, diagnostics);
-                collectAccessorDiagnostics(member, context, diagnostics);
-            }
-            
-            if (hasMapKeyClassAnnotation) {
-                collectTypeDiagnostics(member, "@MapKeyClass", context, diagnostics);      
-                collectAccessorDiagnostics(member, context, diagnostics);
-            }
-            
         }
     }
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -152,10 +152,13 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
                 }
             }
             
-            String attribute = hasMapKeyAnnotation? "@MapKey" : hasMapKeyClassAnnotation? "@MapKeyClass" : null ;
+            if (hasMapKeyAnnotation) {
+                collectTypeDiagnostics(member, "@MapKey", context, diagnostics);
+                collectAccessorDiagnostics(member, context, diagnostics);
+            }
             
-            if (hasMapKeyAnnotation || hasMapKeyClassAnnotation) {
-                collectTypeDiagnostics(member, attribute, context, diagnostics);
+            if(hasMapKeyClassAnnotation) {
+            	collectTypeDiagnostics(member, "@MapKeyClass", context, diagnostics);
                 collectAccessorDiagnostics(member, context, diagnostics);
             }
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/persistence/PersistenceMapKeyDiagnosticsParticipant.java
@@ -185,6 +185,7 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
 
         Range range = null;
         String messageKey = null, typeSignature = null, readableType = null;
+        String packageValue = null, typeValue = null, fqName = null;
         ErrorCode errorCode = null;
 
         boolean isMap=false;
@@ -202,33 +203,34 @@ public class PersistenceMapKeyDiagnosticsParticipant implements IJavaDiagnostics
         	readableType = Signature.toString(Signature.getElementType(typeSignature));
         	
         }
-        
-        
 
         String stripType = readableType.split("<")[0]; // strip Generics 
         String[][] resolveTypes = declaringType.resolveType(stripType);
         
-        String packageValue = resolveTypes[0][0];  // e.g: "java.util"
-        String typeValue = resolveTypes[0][1];     // e.g: "Map"
-        String fqName = packageValue.concat(".").concat(typeValue);
-        
-        if("java.util.Map".equals(fqName)) {
-        	
-        	isMap=true;
-        	
-        }else {
-        	
-        	IType returnType = javaProject.findType(fqName);
-           	ITypeHierarchy hierarchy = returnType.newTypeHierarchy(null);
-           	IType[] interfaces = hierarchy.getAllSuperInterfaces(returnType);
-           	 
-           	for (IType superInterface : interfaces) {
-            	if ("java.util.Map".equals(superInterface.getFullyQualifiedName())) {
-                    isMap=true;
-                }
-            }
+        if(resolveTypes!=null && resolveTypes.length>0) {
+        	 packageValue = resolveTypes[0][0];  // e.g: "java.util"
+             typeValue = resolveTypes[0][1];     // e.g: "Map"
+             fqName = packageValue.concat(".").concat(typeValue);
         }
-        
+       
+		if (fqName != null) {
+			if ("java.util.Map".equals(fqName)) {
+				isMap = true;
+
+			} else {
+
+				IType returnType = javaProject.findType(fqName);
+				ITypeHierarchy hierarchy = returnType.newTypeHierarchy(null);
+				IType[] interfaces = hierarchy.getAllSuperInterfaces(returnType);
+
+				for (IType superInterface : interfaces) {
+					if ("java.util.Map".equals(superInterface.getFullyQualifiedName())) {
+						isMap = true;
+					}
+				}
+			}
+		}
+      
 		if (!isMap) {
 			if (member instanceof IMethod) {
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -127,6 +127,9 @@ MultipleMapKeyJoinColumnMethod = A method with multiple @MapKeyJoinColumn annota
 MultipleMapKeyJoinColumnField = A field with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.
 MapKeyAnnotationsTypeOfField = `{0}` annotation can only be applied to fields of type java.util.Map.
 MapKeyAnnotationsReturnTypeOfMethod = `{0}` annotation can only be applied to methods returning java.util.Map type.
+MapKeyAnnotationsOnInvalidMethod = Method does not conform to JavaBean accessor conventions.
+MapKeyAnnotationsInvalidMethodAccessSpecifier = Method is not public and may not be accessible as expected.
+
 
 # InserMapKeyJoinColumAnnotationAttributesQuickFix
 InsertTheMissingAttributes = Insert the missing attributes to the @MapKeyJoinColumn annotation

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -126,8 +126,8 @@ MapKeyAnnotationsNotOnSameMethod = @MapKeyClass and @MapKey annotations cannot b
 MultipleMapKeyJoinColumnMethod = A method with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.
 MultipleMapKeyJoinColumnField = A field with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.
 MapKeyAnnotationsTypeOfField = `{0}` annotation can only be applied to fields of type java.util.Map.
-MapKeyAnnotationsReturnTypeOfMethod = `{0}` annotation can only be applied to methods returning java.util.Map type.
-MapKeyAnnotationsOnInvalidMethod = Method does not conform to JavaBean accessor conventions.
+MapKeyAnnotationsReturnTypeOfMethod = `{0}` annotation can only be applied to methods with a return type of java.util.Map.
+MapKeyAnnotationsOnInvalidMethod = This method does not conform to persistent property getter naming conventions.
 MapKeyAnnotationsInvalidMethodAccessSpecifier = Method is not public and may not be accessible as expected.
 
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -125,6 +125,8 @@ MapKeyAnnotationsNotOnSameField = @MapKeyClass and @MapKey annotations cannot be
 MapKeyAnnotationsNotOnSameMethod = @MapKeyClass and @MapKey annotations cannot be used on the same method.
 MultipleMapKeyJoinColumnMethod = A method with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.
 MultipleMapKeyJoinColumnField = A field with multiple @MapKeyJoinColumn annotations must specify both the name and referencedColumnName attributes in the corresponding @MapKeyJoinColumn annotations.
+MapKeyAnnotationsTypeOfField = `{0}` annotation can only be applied to fields of type java.util.Map.
+MapKeyAnnotationsReturnTypeOfMethod = `{0}` annotation can only be applied to methods returning java.util.Map type.
 
 # InserMapKeyJoinColumAnnotationAttributesQuickFix
 InsertTheMissingAttributes = Insert the missing attributes to the @MapKeyJoinColumn annotation

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -129,6 +129,7 @@ MapKeyAnnotationsTypeOfField = `{0}` annotation can only be applied to fields of
 MapKeyAnnotationsReturnTypeOfMethod = `{0}` annotation can only be applied to methods with a return type of java.util.Map.
 MapKeyAnnotationsOnInvalidMethod = This method does not conform to persistent property getter naming conventions.
 MapKeyAnnotationsInvalidMethodAccessSpecifier = Method is not public and may not be accessible as expected.
+MapKeyAnnotationsFieldNotFound = Method has no matching field name.
 
 
 # InserMapKeyJoinColumAnnotationAttributesQuickFix


### PR DESCRIPTION
Fix for: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/532
Add new diagnostics for MapKey annotations

1) Check Access Specifier is public and following JavaBean Accessor naming conventions
2) Check return type of Field or Method is a Map type