### PR TITLE
Fix to address JavaCursorContextKind IllegalArgumentException

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -226,6 +226,8 @@ public enum JavaCursorContextKind {
 
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+        //Root cause for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520. See issue for more details.
+        //Fix for Issue 520 lsp4jakarta author: archana-1924
         if (value == NONE.getValue()) {
             return allValues[allValues.length - 1];
         } else {

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2023 Red Hat Inc. and others.
+* Copyright (c) 2023, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -224,17 +224,15 @@ public enum JavaCursorContextKind {
         return value;
     }
 
-    public static JavaCursorContextKind forValue(int value) {
-        JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-		
-        // Root cause and fix for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520.
-		// See issue for more details.		
+	public static JavaCursorContextKind forValue(int value) {
+		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+
+		// Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
 		if (value == NONE.getValue()) {
 			return NONE;
-		} else {
-			if (value < 1 || value > allValues.length)
-				throw new IllegalArgumentException("Illegal enum value: " + value);
-			return allValues[value - 1];
 		}
-    }
+		if (value < 1 || value > allValues.length-1)
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		return allValues[value - 1];
+	}
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -224,15 +224,15 @@ public enum JavaCursorContextKind {
         return value;
     }
 
-	public static JavaCursorContextKind forValue(int value) {
-		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+    public static JavaCursorContextKind forValue(int value) {
+        JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
 
-		// Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
-		if (value == NONE.getValue()) {
-			return NONE;
-		}
-		if (value < 1 || value > allValues.length - 1)
-			throw new IllegalArgumentException("Illegal enum value: " + value);
-		return allValues[value - 1];
-	}
+        // Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
+        if (value == NONE.getValue()) {
+            return NONE;
+        }
+        if (value < 1 || value > allValues.length - 1)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -231,7 +231,7 @@ public enum JavaCursorContextKind {
 		if (value == NONE.getValue()) {
 			return NONE;
 		}
-		if (value < 1 || value > allValues.length-1)
+		if (value < 1 || value > allValues.length - 1)
 			throw new IllegalArgumentException("Illegal enum value: " + value);
 		return allValues[value - 1];
 	}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -227,7 +227,7 @@ public enum JavaCursorContextKind {
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
 		
-        // Root cause for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520.
+        // Root cause and fix for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520.
 		// See issue for more details.		
 		if (value == NONE.getValue()) {
 			return NONE;

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -226,8 +226,12 @@ public enum JavaCursorContextKind {
 
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-        if (value < 1 || value > allValues.length)
-            throw new IllegalArgumentException("Illegal enum value: " + value);
-        return allValues[value - 1];
+        if (value == NONE.getValue()) {
+            return allValues[allValues.length - 1];
+        } else {
+	        if (value < 1 || value > allValues.length)
+	            throw new IllegalArgumentException("Illegal enum value: " + value);
+	        return allValues[value - 1];
+        }
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -226,14 +226,15 @@ public enum JavaCursorContextKind {
 
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-        //Root cause for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520. See issue for more details.
-        //Fix for Issue 520 lsp4jakarta author: archana-1924
-        if (value == NONE.getValue()) {
-            return allValues[allValues.length - 1];
-        } else {
-	        if (value < 1 || value > allValues.length)
-	            throw new IllegalArgumentException("Illegal enum value: " + value);
-	        return allValues[value - 1];
-        }
+		
+        // Root cause for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520.
+		// See issue for more details.		
+		if (value == NONE.getValue()) {
+			return NONE;
+		} else {
+			if (value < 1 || value > allValues.length)
+				throw new IllegalArgumentException("Illegal enum value: " + value);
+			return allValues[value - 1];
+		}
     }
 }

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -226,6 +226,8 @@ public enum JavaCursorContextKind {
 
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+        //Root cause for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520. See issue for more details.
+        //Fix for Issue 520 lsp4jakarta author: archana-1924
         if (value == NONE.getValue()) {
             return allValues[allValues.length - 1];
         } else {

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -224,16 +224,16 @@ public enum JavaCursorContextKind {
         return value;
     }
 
-	public static JavaCursorContextKind forValue(int value) {
-		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+    public static JavaCursorContextKind forValue(int value) {
+        JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
 
-		// Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
-		if (value == NONE.getValue()) {
-			return NONE;
-		}
-		if (value < 1 || value > allValues.length - 1)
-			throw new IllegalArgumentException("Illegal enum value: " + value);
-		return allValues[value - 1];
-	}
+        // Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
+        if (value == NONE.getValue()) {
+            return NONE;
+        }
+        if (value < 1 || value > allValues.length - 1)
+            throw new IllegalArgumentException("Illegal enum value: " + value);
+        return allValues[value - 1];
+    }
 
 }

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -227,7 +227,7 @@ public enum JavaCursorContextKind {
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
         
-        //Root cause for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520.
+        //Root cause and fix for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520.
         //See issue for more details.
         if (value == NONE.getValue()) {
             return NONE;

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -231,7 +231,7 @@ public enum JavaCursorContextKind {
 		if (value == NONE.getValue()) {
 			return NONE;
 		}
-		if (value < 1 || value > allValues.length-1)
+		if (value < 1 || value > allValues.length - 1)
 			throw new IllegalArgumentException("Illegal enum value: " + value);
 		return allValues[value - 1];
 	}

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -226,12 +226,13 @@ public enum JavaCursorContextKind {
 
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-        //Root cause for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520. See issue for more details.
-        //Fix for Issue 520 lsp4jakarta author: archana-1924
+        
+        //Root cause for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520.
+        //See issue for more details.
         if (value == NONE.getValue()) {
-            return allValues[allValues.length - 1];
+            return NONE;
         } else {
-            if (value < 1 || value > allValues.length)
+        	if (value < 1 || value > allValues.length)
                 throw new IllegalArgumentException("Illegal enum value: " + value);
             return allValues[value - 1];
         }

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -226,9 +226,13 @@ public enum JavaCursorContextKind {
 
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-        if (value < 1 || value > allValues.length)
-            throw new IllegalArgumentException("Illegal enum value: " + value);
-        return allValues[value - 1];
+        if (value == NONE.getValue()) {
+            return allValues[allValues.length - 1];
+        } else {
+            if (value < 1 || value > allValues.length)
+                throw new IllegalArgumentException("Illegal enum value: " + value);
+            return allValues[value - 1];
+        }
     }
 
 }

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2023 Red Hat Inc. and others.
+* Copyright (c) 2023, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -224,18 +224,16 @@ public enum JavaCursorContextKind {
         return value;
     }
 
-    public static JavaCursorContextKind forValue(int value) {
-        JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-        
-        //Root cause and fix for https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520.
-        //See issue for more details.
-        if (value == NONE.getValue()) {
-            return NONE;
-        } else {
-        	if (value < 1 || value > allValues.length)
-                throw new IllegalArgumentException("Illegal enum value: " + value);
-            return allValues[value - 1];
-        }
-    }
+	public static JavaCursorContextKind forValue(int value) {
+		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+
+		// Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
+		if (value == NONE.getValue()) {
+			return NONE;
+		}
+		if (value < 1 || value > allValues.length-1)
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		return allValues[value - 1];
+	}
 
 }


### PR DESCRIPTION
The PR addresses Issue: https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520
 Root causes were observed in JavaCursorContextKind.java files in 
>lsp4jakarta.ls
>lsp4jakarta.jdt