### PR TITLE
Fixes issue #520:  Changed value of NONE type to keep in sync with lsp4mp

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -245,12 +245,7 @@ public enum JavaCursorContextKind {
 
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-
-        // Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
-        if (value == NONE.getValue()) {
-            return NONE;
-        }
-        if (value < 1 || value > allValues.length - 1)
+        if (value < 1 || value > allValues.length) //Refactored the code as enum values are synced up with lsp4mp, for issue #520
             throw new IllegalArgumentException("Illegal enum value: " + value);
         return allValues[value - 1];
     }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -212,7 +212,7 @@ public enum JavaCursorContextKind {
      * }<br />
      * </code>
      */
-    NONE(2000);
+    NONE(10);
 
     private final int value;
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -194,6 +194,25 @@ public enum JavaCursorContextKind {
      * </code>
      */
     IN_CLASS(8),
+    
+    /**
+     * Added as part of syncing up ls4mp and lsp4jakarta as part of issue #520. This value could be used for future enhancements.
+     * The cursor is before a type declaration body at the root of a file.
+     * The cursor is before any annotations on the type.
+     *
+     * eg.
+     * <code>
+     * <br />
+     * package org.acme;<br />
+     * <br />
+     * |<br />
+     * &commat;Inject<br />
+     * public class MyClass {<br />
+     * <br />
+     * }<br />
+     * </code>
+     */
+    BEFORE_TOP_LEVEL_CLASS(9),
 
     /**
      * None of the above context apply.

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -245,12 +245,7 @@ public enum JavaCursorContextKind {
 
     public static JavaCursorContextKind forValue(int value) {
         JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
-
-        // Root cause and fix for JavaCursorContextKind IllegalArgumentException issue #520 when value passed is 2000
-        if (value == NONE.getValue()) {
-            return NONE;
-        }
-        if (value < 1 || value > allValues.length - 1)
+        if (value < 1 || value > allValues.length) //Refactored the code as enum values are synced up with lsp4mp, for issue #520
             throw new IllegalArgumentException("Illegal enum value: " + value);
         return allValues[value - 1];
     }

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -212,7 +212,7 @@ public enum JavaCursorContextKind {
      * }<br />
      * </code>
      */
-    NONE(2000);
+    NONE(10);
 
     private final int value;
 

--- a/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
+++ b/jakarta.ls/src/main/java/org/eclipse/lsp4jakarta/commons/JavaCursorContextKind.java
@@ -194,6 +194,25 @@ public enum JavaCursorContextKind {
      * </code>
      */
     IN_CLASS(8),
+    
+    /**
+     * Added as part of syncing up ls4mp and lsp4jakarta as part of issue #520. This value could be used for future enhancements.
+     * The cursor is before a type declaration body at the root of a file.
+     * The cursor is before any annotations on the type.
+     *
+     * eg.
+     * <code>
+     * <br />
+     * package org.acme;<br />
+     * <br />
+     * |<br />
+     * &commat;Inject<br />
+     * public class MyClass {<br />
+     * <br />
+     * }<br />
+     * </code>
+     */
+    BEFORE_TOP_LEVEL_CLASS(9),
 
     /**
      * None of the above context apply.

--- a/jakarta.ls/src/test/java/org/eclipse/lsp4jakarta/snippets/JakartaSnippetRegistryTest.java
+++ b/jakarta.ls/src/test/java/org/eclipse/lsp4jakarta/snippets/JakartaSnippetRegistryTest.java
@@ -110,6 +110,7 @@ public class JakartaSnippetRegistryTest {
         assertTrue("rest_head Java snippet is not present in SnippetRegistry", restHeadSnippet.isPresent());
 
         snippetsContextTest(restClassSnippet, "jakarta.ws.rs.GET", JavaCursorContextKind.IN_EMPTY_FILE);
+        snippetsContextTest(restGetSnippet, "jakarta.ws.rs.GET", JavaCursorContextKind.NONE);
         snippetsContextTest(restGetSnippet, "jakarta.ws.rs.GET", JavaCursorContextKind.BEFORE_METHOD);
         snippetsContextTest(restPostSnippet, "jakarta.ws.rs.POST", JavaCursorContextKind.BEFORE_METHOD);
         snippetsContextTest(restPutSnippet, "jakarta.ws.rs.PUT", JavaCursorContextKind.BEFORE_METHOD);
@@ -192,7 +193,11 @@ public class JakartaSnippetRegistryTest {
         ProjectLabelInfoEntry projectInfo1 = new ProjectLabelInfoEntry("", null, Arrays.asList(contextType));
         boolean match1 = ((SnippetContextForJava) context).isMatch(context(projectInfo1, javaCursorContextKind,
                                                                            snippet.get().getPrefixes().isEmpty() ? "" : snippet.get().getPrefixes().get(0)));
-        assertTrue("Project has no " + contextType + " type", match1);
+        if (javaCursorContextKind.getValue() == 10) {
+            assertFalse("Project should not have " + contextType + " type", match);
+        } else {
+            assertTrue("Project has no " + contextType + " type", match1);
+        }
 
     }
 


### PR DESCRIPTION
This PR is to sync up the enum value change made in lsp4mp (https://github.com/eclipse-lsp4mp/lsp4mp/pull/502) as part of lsp4jakarta issue (https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/520)