### PR TITLE
New test case for Type check and Method naming conventions : Issue-532

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/META-INF/MANIFEST.MF
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Require-Bundle:
  org.eclipse.lsp4jakarta.jdt.core,
  org.eclipse.m2e.core,
  org.eclipse.m2e.maven.runtime,
+ org.mockito.mockito-core,
  org.eclipse.jdt.ls.core;resolution:=optional
 Bundle-ClassPath: . 
-Import-Package: com.google.gson
+Import-Package: com.google.gson,org.mockito

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAnnotationsGetterConvention.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAnnotationsGetterConvention.java
@@ -1,0 +1,52 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.persistence.MapKey;
+import jakarta.persistence.MapKeyClass;
+
+public class MapKeyAnnotationsGetterConvention {
+
+    Integer age;
+
+    
+    String name;
+
+    Map<Integer, String> place;
+
+    Map<Integer, String> gender;
+
+    Map<Integer, String> testMap = new HashMap<>();
+
+    
+    @MapKeyClass(Map.class)
+    public Map<Integer, String> getTestMap() {
+        return this.testMap;
+    }
+
+    
+    public Integer getAge() {
+        return this.age;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    @MapKeyClass(Map.class)
+    private Map<Integer, String> getPlace() {
+        return this.place;
+    }
+
+    @MapKey()
+    public  Map<Integer, String> geGender() {
+        return null;
+    }
+
+    @MapKey()
+    public Map<Integer, String> getPerform() {
+        return "";
+    }
+
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAnnotationsType.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAnnotationsType.java
@@ -1,0 +1,40 @@
+package io.openliberty.sample.jakarta.persistence;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.persistence.MapKey;
+import jakarta.persistence.MapKeyClass;
+
+public class MapKeyAnnotationsType {
+
+    Integer age;
+
+    @MapKey()
+    String name;
+
+    Map<Integer, String> place;
+
+    Map<Integer, String> gender;
+
+    Map<Integer, String> testMap = new HashMap<>();
+
+    @MapKeyClass(Map.class)
+    public Map<Integer, String> getTestMap() {
+        return this.testMap;
+    }
+
+    @MapKey()
+    public Integer getAge() {
+        return this.age;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    private Map<Integer, String> getPlace() {
+        return this.place;
+    }
+
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAnnotationsType.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAnnotationsType.java
@@ -19,7 +19,7 @@ public class MapKeyAnnotationsType {
 
     Map<Integer, String> testMap = new HashMap<>();
 
-    @MapKeyClass(Map.class)
+   
     public Map<Integer, String> getTestMap() {
         return this.testMap;
     }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/persistence/JakartaPersistenceTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/persistence/JakartaPersistenceTest.java
@@ -50,10 +50,10 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
         IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
 
         IFile javaFile = javaProject.getProject().getFile(
-                                                          new Path("src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAndMapKeyClassTogether.java"));
+                new Path("src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAndMapKeyClassTogether.java"));
         String uri = javaFile.getLocation().toFile().toURI().toString();
 
-        //JDTTypeUtils
+        // JDTTypeUtils
 
         try (MockedStatic<JDTTypeUtils> mocked = mockStatic(JDTTypeUtils.class)) {
             mocked.when(() -> JDTTypeUtils.getResolvedResultTypeName(any(IMethod.class))).thenReturn("java.util.Map");
@@ -63,12 +63,12 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
             diagnosticsParams.setUris(Arrays.asList(uri));
 
             Diagnostic d1 = d(16, 32, 42,
-                              "@MapKeyClass and @MapKey annotations cannot be used on the same method.",
-                              DiagnosticSeverity.Error, "jakarta-persistence", "InvalidMapKeyAnnotationsOnSameMethod");
+                    "@MapKeyClass and @MapKey annotations cannot be used on the same method.",
+                    DiagnosticSeverity.Error, "jakarta-persistence", "InvalidMapKeyAnnotationsOnSameMethod");
 
             Diagnostic d2 = d(11, 25, 32,
-                              "@MapKeyClass and @MapKey annotations cannot be used on the same field or property.",
-                              DiagnosticSeverity.Error, "jakarta-persistence", "InvalidMapKeyAnnotationsOnSameField");
+                    "@MapKeyClass and @MapKey annotations cannot be used on the same field or property.",
+                    DiagnosticSeverity.Error, "jakarta-persistence", "InvalidMapKeyAnnotationsOnSameField");
 
             assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, d1, d2);
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/persistence/JakartaPersistenceTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/persistence/JakartaPersistenceTest.java
@@ -250,4 +250,27 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
 
         assertJavaCodeAction(codeActionParams5, IJDT_UTILS, ca5);
     }
+    
+    @Test
+    public void testMethodOrFieldType()throws Exception{
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+
+        IFile javaFile = javaProject.getProject().getFile(
+                                                          new Path("src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAnnotationsType.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+        
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic d1 = d(27, 19, 25,
+                          "`@MapKey` annotation can only be applied to methods with a return type of java.util.Map.",
+                          DiagnosticSeverity.Error, "jakarta-persistence", "InvalidReturnTypeOfMethod");
+
+        Diagnostic d2 = d(13, 11, 15,
+                          "`@MapKey` annotation can only be applied to fields of type java.util.Map.",
+                          DiagnosticSeverity.Error, "jakarta-persistence", "InvalidTypeOfField");
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, d1, d2);
+    }
+    
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/persistence/JakartaPersistenceTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/persistence/JakartaPersistenceTest.java
@@ -47,17 +47,17 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
 
     @Test
     public void deleteMapKeyOrMapKeyClass() throws Exception {
+        final String MAP_INTERFACE_FQDN = "java.util.Map";
         IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
 
         IFile javaFile = javaProject.getProject().getFile(
                 new Path("src/main/java/io/openliberty/sample/jakarta/persistence/MapKeyAndMapKeyClassTogether.java"));
         String uri = javaFile.getLocation().toFile().toURI().toString();
-
-        // JDTTypeUtils
-
+       
         try (MockedStatic<JDTTypeUtils> mocked = mockStatic(JDTTypeUtils.class)) {
-            mocked.when(() -> JDTTypeUtils.getResolvedResultTypeName(any(IMethod.class))).thenReturn("java.util.Map");
-            mocked.when(() -> JDTTypeUtils.getResolvedTypeName(any(IField.class))).thenReturn("java.util.Map");
+            mocked.when(() -> JDTTypeUtils.getResolvedResultTypeName(any(IMethod.class)))
+                    .thenReturn(MAP_INTERFACE_FQDN);
+            mocked.when(() -> JDTTypeUtils.getResolvedTypeName(any(IField.class))).thenReturn(MAP_INTERFACE_FQDN);
 
             JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
             diagnosticsParams.setUris(Arrays.asList(uri));


### PR DESCRIPTION
New test cases added for issue https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/532
1. Test the return type of method/ type of field
2. Test the naming convention of getter method and access specifier