### PR TITLE
Test failure fix for issue: 532

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/core/BaseJakartaTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/core/BaseJakartaTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 Red Hat Inc. and others.
+* Copyright (c) 2019, 2025 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/core/BaseJakartaTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/core/BaseJakartaTest.java
@@ -16,6 +16,7 @@ package org.eclipse.lsp4jakarta.jdt.core;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.resources.IProject;
@@ -33,7 +34,6 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 
-
 /**
  * Modified from:
  * https://github.com/eclipse/lsp4mp/blob/bc926f75df2ca103d78c67b997c87adb7ab480b1/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/BasePropertiesManagerTest.java
@@ -41,6 +41,8 @@ import org.eclipse.jdt.internal.core.JavaModelManager;
  *
  */
 public class BaseJakartaTest {
+
+    private static final Logger LOGGER = Logger.getLogger(BaseJakartaTest.class.getName());
 
     protected static IJavaProject loadJavaProject(String projectName, String parentDirName) throws CoreException, Exception {
         // Move project to working directory
@@ -94,7 +96,7 @@ public class BaseJakartaTest {
 
                 javaProject.setRawClasspath(newClasspath, null);
 
-                System.out.println("Added jrt-fs.jar to classpath");
+                LOGGER.info("Added jrt-fs.jar to classpath");
             }
 
         } catch (JavaModelException e) {

--- a/jakarta.jdt/pom.xml
+++ b/jakarta.jdt/pom.xml
@@ -162,7 +162,7 @@
                         <version>${tycho.version}</version>
                         <configuration>
                             <useUIHarness>false</useUIHarness>
-                            <argLine>-Xmx512m -XstartOnFirstThread</argLine>
+                            <argLine>-Xmx2g -XstartOnFirstThread</argLine>
                             <!-- kill test JVM if tests take more than 1 minute (60 seconds) to
                                 finish -->
                             <forkedProcessTimeoutInSeconds>60</forkedProcessTimeoutInSeconds>


### PR DESCRIPTION
This is a fix for test failures as part of changes related to issue https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/532.

Here we use following internal class method to resolve the type of Field or Method.  
JavaModelUtil.getResolvedTypeName (Eclipse JDT Core)
This is returning empty output when run from terminal(using mvn command). But works if we run inside eclipse.

Root cause : jrt-fs.jar (Internal to JDK) not properly adding to class path when run from terminal. 

