### PR TITLE
Dependency Injection: Diagnostics for non-static inner class managed bean

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/plugin.xml
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/plugin.xml
@@ -145,6 +145,12 @@
                   targetDiagnostic="jakarta-di#InvalidInjectAnnotationOnFinalField"
                   class="org.eclipse.lsp4jakarta.jdt.internal.di.RemoveInjectAnnotationQuickFix" />
       <codeAction kind="quickfix"
+                  targetDiagnostic="jakarta-di#InvalidInjectAnnotationOnNonStaticInnerClass"
+                  class="org.eclipse.lsp4jakarta.jdt.internal.di.RemoveInjectAnnotationQuickFix" />
+      <codeAction kind="quickfix"
+                  targetDiagnostic="jakarta-di#InvalidInjectAnnotationOnNonStaticInnerClass"
+                  class="org.eclipse.lsp4jakarta.jdt.internal.di.InsertStaticModifierQuickFix" />                 
+      <codeAction kind="quickfix"
                   targetDiagnostic="jakarta-di#InvalidInjectAnnotationOnFinalField"
                   class="org.eclipse.lsp4jakarta.jdt.internal.di.RemoveFinalModifierQuickFix" />
       <codeAction kind="quickfix"

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/codeaction/JakartaCodeActionId.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/commons/codeaction/JakartaCodeActionId.java
@@ -23,6 +23,7 @@ public enum JakartaCodeActionId implements ICodeActionId {
     jaxrsInsertPublicCtrtToClass,
     MakeConstructorPublic,
     MakeMethodPublic,
+    MakeMethodStatic,
     RemoveAllEntityParametersExcept,
     // Annotations
     ChangeReturnTypeToVoid,

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/DependencyInjectionDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/DependencyInjectionDiagnosticsParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021, 2024 IBM Corporation and others.
+* Copyright (c) 2021, 2025 IBM Corporation and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -30,6 +30,7 @@ import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Range;
@@ -70,16 +71,26 @@ public class DependencyInjectionDiagnosticsParticipant implements IJavaDiagnosti
         for (IType type : alltypes) {
             IField[] allFields = type.getFields();
             for (IField field : allFields) {
-                if (Flags.isFinal(field.getFlags())
-                    && containsAnnotation(type, field.getAnnotations(), INJECT_FQ_NAME)) {
-                    String msg = Messages.getMessage("InjectNoFinalField");
-                    Range range = PositionUtils.toNameRange(field,
-                                                            context.getUtils());
-                    diagnostics.add(
-                                    context.createDiagnostic(uri, msg, range, Constants.DIAGNOSTIC_SOURCE,
-                                                             ErrorCode.InvalidInjectAnnotationOnFinalField,
-                                                             DiagnosticSeverity.Error));
+                Range range = PositionUtils.toNameRange(field,
+                                                        context.getUtils());
+                if (containsAnnotation(type, field.getAnnotations(), INJECT_FQ_NAME)) {
+                    if (Flags.isFinal(field.getFlags())) {
+                        String msg = Messages.getMessage("InjectNoFinalField");
+
+                        diagnostics.add(
+                                        context.createDiagnostic(uri, msg, range, Constants.DIAGNOSTIC_SOURCE,
+                                                                 ErrorCode.InvalidInjectAnnotationOnFinalField,
+                                                                 DiagnosticSeverity.Error));
+                    }
+                    if (hasNonStaticInnerClass(type, Signature.toString(field.getTypeSignature()))) {
+                        String msg = Messages.getMessage("InjectNonStaticInnerClass");
+                        diagnostics.add(
+                                        context.createDiagnostic(uri, msg, range, Constants.DIAGNOSTIC_SOURCE,
+                                                                 ErrorCode.InvalidInjectAnnotationOnNonStaticInnerClass,
+                                                                 DiagnosticSeverity.Error));
+                    }
                 }
+
             }
 
             List<IMethod> injectedConstructors = new ArrayList<IMethod>();
@@ -119,6 +130,16 @@ public class DependencyInjectionDiagnosticsParticipant implements IJavaDiagnosti
                                                                  ErrorCode.InvalidInjectAnnotationOnGenericMethod,
                                                                  DiagnosticSeverity.Error));
                     }
+                    String[] paramTypes = method.getParameterTypes();
+                    for (String paramType : paramTypes) {
+                        if (hasNonStaticInnerClass(type, Signature.toString(paramType))) {
+                            String msg = Messages.getMessage("InjectNonStaticInnerClass");
+                            diagnostics.add(context.createDiagnostic(uri, msg, range, Constants.DIAGNOSTIC_SOURCE,
+                                                                     ErrorCode.InvalidInjectAnnotationOnNonStaticInnerClass,
+                                                                     DiagnosticSeverity.Error));
+                        }
+                    }
+
                 }
             }
 
@@ -162,6 +183,15 @@ public class DependencyInjectionDiagnosticsParticipant implements IJavaDiagnosti
                 return false;
             }
         });
+    }
+
+    private boolean hasNonStaticInnerClass(IType outerType, String injectedTypeName) throws JavaModelException {
+        for (IType inner : outerType.getTypes()) {
+            if (inner.getFullyQualifiedName().endsWith(injectedTypeName)) {
+                return !Flags.isStatic(inner.getFlags());
+            }
+        }
+        return false;
     }
 
     /**

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/ErrorCode.java
@@ -19,6 +19,7 @@ import org.eclipse.lsp4jakarta.jdt.core.java.diagnostics.IJavaErrorCode;
  */
 public enum ErrorCode implements IJavaErrorCode {
     InvalidInjectAnnotationOnFinalField,
+    InvalidInjectAnnotationOnNonStaticInnerClass,
     InvalidInjectAnnotationOnFinalMethod,
     InvalidInjectAnnotationOnAbstractMethod,
     InvalidInjectAnnotationOnStaticMethod,

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/InsertStaticModifierQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/InsertStaticModifierQuickFix.java
@@ -58,7 +58,33 @@ public class InsertStaticModifierQuickFix implements IJavaCodeActionParticipant 
         super();
     }
 
-  
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context,
+                                                     Diagnostic diagnostic,
+                                                     IProgressMonitor monitor) throws CoreException {
+        ASTNode node = context.getCoveredNode();
+        List<CodeAction> codeActions = new ArrayList<>();
+        if (node == null) {
+            return codeActions;
+        }
+        IBinding parentType = getBinding(node);
+        if (parentType != null) {
+            ExtendedCodeAction codeAction = new ExtendedCodeAction(getLabel());
+            codeAction.setRelevance(0);
+            codeAction.setKind(CodeActionKind.QuickFix);
+            codeAction.setDiagnostics(Arrays.asList(diagnostic));
+            codeAction.setData(new CodeActionResolveData(context.getUri(), getParticipantId(), context.getParams().getRange(), null, context.getParams().isResourceOperationSupported(), context.getParams().isCommandConfigurationUpdateSupported(), getCodeActionId()));
+
+            codeActions.add(codeAction);
+        }
+
+        return codeActions;
+    }
+
+   
     protected String getLabel() {
         return Messages.getMessage("MakeInnerClassStatic");
     }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/InsertStaticModifierQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/InsertStaticModifierQuickFix.java
@@ -100,7 +100,13 @@ public class InsertStaticModifierQuickFix implements IJavaCodeActionParticipant 
                 makeMemberTypeStaticIfNeeded(context, toResolve, fieldType);
             }
         }
-       
+        // Case 2: @Inject on a method
+        else if (node.getParent() instanceof MethodDeclaration) {
+            IMethodBinding methodBinding = (IMethodBinding) getBinding(node);
+            for (ITypeBinding paramType : methodBinding.getParameterTypes()) {
+                makeMemberTypeStaticIfNeeded(context, toResolve, paramType);
+            }
+        }
 
         return toResolve;
     }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/InsertStaticModifierQuickFix.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/di/InsertStaticModifierQuickFix.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+* Copyright (c) 2025 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     IBM Corporation - initial implementation
+*******************************************************************************/
+package org.eclipse.lsp4jakarta.jdt.internal.di;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4jakarta.commons.codeaction.CodeActionResolveData;
+import org.eclipse.lsp4jakarta.commons.codeaction.ICodeActionId;
+import org.eclipse.lsp4jakarta.commons.codeaction.JakartaCodeActionId;
+import org.eclipse.lsp4jakarta.jdt.core.java.codeaction.ExtendedCodeAction;
+import org.eclipse.lsp4jakarta.jdt.core.java.codeaction.IJavaCodeActionParticipant;
+import org.eclipse.lsp4jakarta.jdt.core.java.codeaction.JavaCodeActionContext;
+import org.eclipse.lsp4jakarta.jdt.core.java.codeaction.JavaCodeActionResolveContext;
+import org.eclipse.lsp4jakarta.jdt.core.java.corrections.proposal.ModifyModifiersProposal;
+import org.eclipse.lsp4jakarta.jdt.internal.Messages;
+
+/**
+ * Removes the static modifier from the declaring element.
+ */
+public class InsertStaticModifierQuickFix implements IJavaCodeActionParticipant {
+
+    /** Logger object to record events for this class. */
+    private static final Logger LOGGER = Logger.getLogger(InsertStaticModifierQuickFix.class.getName());
+
+    /**
+     * Constructor.
+     */
+    public InsertStaticModifierQuickFix() {
+        super();
+    }
+
+  
+    protected String getLabel() {
+        return Messages.getMessage("MakeInnerClassStatic");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected ICodeActionId getCodeActionId() {
+        return JakartaCodeActionId.MakeMethodStatic;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getParticipantId() {
+        return InsertStaticModifierQuickFix.class.getName();
+    }
+
+    /**
+     * Returns the named entity associated to the given node.
+     *
+     * @param node The AST Node
+     *
+     * @return The named entity associated to the given node.
+     */
+    @SuppressWarnings("restriction")
+    protected IBinding getBinding(ASTNode node) {
+        if (node.getParent() instanceof VariableDeclarationFragment) {
+            return ((VariableDeclarationFragment) node.getParent()).resolveBinding();
+        } else if (node.getParent() instanceof MethodDeclaration) {
+            return ((MethodDeclaration) node.getParent()).resolveBinding();
+        }
+        return org.eclipse.jdt.internal.corext.dom.Bindings.getBindingOfParentType(node);
+    }
+
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -80,6 +80,7 @@ InjectNoAbstractMethod = The @Inject annotation must not define an abstract meth
 InjectNoStaticMethod = The @Inject annotation must not define a static method.
 InjectNoGenericMethod = The @Inject annotation must not define a generic method.
 InjectMoreThanOneConstructor = The @Inject annotation must not define more than one constructor.
+InjectNonStaticInnerClass = Cannot inject non-static inner class. Injection target must be a top-level or static nested class.
 InjectionPointInvalidPrimitiveBean = The parameter should not be a primitive type.
 InjectionPointInvalidInnerClassBean = The parameter should not be an inner class.
 InjectionPointInvalidAbstractClassBean = The parameter should not contain the abstract modifier. If it contains the abstract modifier, the class should be annotated with @Decorator.
@@ -95,6 +96,9 @@ MultipleConstructorsNumberOfParameters = Multiple constructors have the same num
 
 # UpdateMethodAccessToPublicQuickFix
 MakeMethodPublic = Make method public
+
+# UpdateMethodModifierToStaticQuickFix
+MakeInnerClassStatic = Make inner class static
 
 # UpdateContructorAccessToPublicQuickFix
 MakeConstructorPublic = Make constructor public


### PR DESCRIPTION
This is to address the issue #192 

If it's a non-static inner class, CDI cannot instantiate it without an enclosing instance of the outer class. 
That’s a hard structural limitation, independent of bean scope or discovery mode.
Reference -> https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0#what_classes_are_beans