### PR TITLE
Fix for issue #291: Added diagnostic for Jsonb property uniqueness

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/jsonb/Constants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/jsonb/Constants.java
@@ -28,6 +28,7 @@ public class Constants {
 
     public static final String JSONB_CREATOR = JSONB_PACKAGE + JSONB_PREFIX + "Creator";
     public static final int MAX_METHOD_WITH_JSONBCREATOR = 1;
+    public static final int DUPLICATE_PROPERTY_VALUE = 1;
 
     public static final String JSONB_TRANSIENT = JSONB_PREFIX + "Transient";
     public static final String JSONB_TRANSIENT_FQ_NAME = JSONB_PACKAGE + JSONB_TRANSIENT;


### PR DESCRIPTION
This PR contains fixes for issue [#291](https://github.com/eclipse-lsp4jakarta/lsp4jakarta/issues/291)

The diagnostic is generated for the below scenarios:
* JSON classes having duplicate property name values
* JSON classes with unicode duplicate property name values
* JSON subclasses with duplicate property name values