### PR TITLE
Fix null value causing codeAction error

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/JDTUtilsLSImpl.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/core/ls/JDTUtilsLSImpl.java
@@ -68,13 +68,15 @@ public class JDTUtilsLSImpl implements IJDTUtils {
     @Override
     public ICompilationUnit resolveCompilationUnit(String uriString) {
         ICompilationUnit unit = JDTUtils.resolveCompilationUnit(uriString);
-        try {
-            // Give underlying resource time to catch up
-            // (timeout at COMPILATION_UNIT_UPDATE_TIMEOUT milliseconds).
-            long endTime = System.currentTimeMillis() + COMPILATION_UNIT_UPDATE_TIMEOUT;
-            while (!unit.isConsistent() && System.currentTimeMillis() < endTime) {
+        if (unit != null) {
+            try {
+                // Give underlying resource time to catch up
+                // (timeout at COMPILATION_UNIT_UPDATE_TIMEOUT milliseconds).
+                long endTime = System.currentTimeMillis() + COMPILATION_UNIT_UPDATE_TIMEOUT;
+                while (!unit.isConsistent() && System.currentTimeMillis() < endTime) {
+                }
+            } catch (JavaModelException e) {
             }
-        } catch (JavaModelException e) {
         }
         return unit;
     }


### PR DESCRIPTION
Seeing an intermittent error when opening Java files in VSCode:
<img width="462" height="108" alt="Screenshot 2025-09-25 at 12 09 54 PM" src="https://github.com/user-attachments/assets/7ca902dd-4664-4afc-bf3c-1550c8267875" />
```
[Error - 11:05:12 AM] Request textDocument/codeAction failed.
  Message: Request jakarta/java/codeAction failed with message: Cannot invoke "org.eclipse.jdt.core.ICompilationUnit.isConsistent()" because "unit" is null
  Code: -32603 
```

Added a check to avoid operating on a null `ICompilationUnit`. Not seeing the error after this change.