### PR TITLE
Fix annotation removal collapsing line break and overlapping text edits

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
@@ -124,7 +124,7 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
                 continue;
             }
             ITypeBinding binding = annotation.resolveTypeBinding();
-            if (!binding.getQualifiedName().equals(matchingFqn)) {
+            if (binding == null || !binding.getQualifiedName().equals(matchingFqn)) {
                 continue;
             }
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
@@ -195,14 +195,19 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
                         }
                         scan--;
                     }
-                    // If the preceding line is itself an annotation, do not absorb backward —
-                    // absorbing into another annotation's line would corrupt that annotation.
+                    // If the preceding line is an annotation or a comment, do not absorb
+                    // backward — absorbing into an annotation would corrupt it, and
+                    // absorbing into a comment would produce confusing output.
                     if (prevLineHasContent) {
                         int prevLineStart = prevLineEnd - 1;
                         while (prevLineStart > 0 && source.charAt(prevLineStart - 1) != '\n') {
                             prevLineStart--;
                         }
-                        if (source.substring(prevLineStart, prevLineEnd).stripLeading().startsWith("@")) {
+                        String prevLineContent = source.substring(prevLineStart, prevLineEnd).stripLeading();
+                        if (prevLineContent.startsWith("@")
+                                || prevLineContent.startsWith("//")
+                                || prevLineContent.startsWith("/*")
+                                || prevLineContent.startsWith("*")) {
                             prevLineHasContent = false;
                         }
                     }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
@@ -13,6 +13,7 @@
 *******************************************************************************/
 package org.eclipse.lsp4jakarta.jdt.core.java.corrections.proposal;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -109,8 +110,10 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
         }
 
         String source = document.get();
+        List<int[]> pendingDeletes = new ArrayList<>();
 
-        for (ASTNode child : children) {
+        for (int i = 0; i < children.size(); i++) {
+            ASTNode child = children.get(i);
             if (!(child instanceof Annotation)) {
                 continue;
             }
@@ -135,46 +138,124 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
                 lineStart--;
             }
 
-            // Find the end of the line containing this annotation.
+            // Find the end of the line containing this annotation (exclusive of \n).
             int lineEnd = annotEnd;
             while (lineEnd < source.length() && source.charAt(lineEnd) != '\n') {
                 lineEnd++;
             }
 
-            // Check whether the annotation is the only non-whitespace token on its line.
+            // Content before and after the annotation on the same line.
             String before = source.substring(lineStart, annotStart);
             String after = source.substring(annotEnd, lineEnd);
-            boolean aloneOnLine = before.trim().isEmpty() && after.trim().isEmpty();
+
+            boolean atLineEnd = after.trim().isEmpty();
 
             int deleteStart;
             int deleteEnd;
 
-            if (aloneOnLine) {
-                // Delete the entire line including its leading indentation and trailing newline,
-                // so no blank line is left behind.
-                deleteStart = lineStart;
-                deleteEnd = (lineEnd < source.length() && source.charAt(lineEnd) == '\n') ? lineEnd + 1 : lineEnd;
-            } else {
-                // The annotation shares its line with other tokens.
-                // Every annotation eats its trailing space (the separator after it).
-                // First token also eats leading indentation (deleteStart = lineStart).
-                // Later tokens start at annotStart since their preceding space was already
-                // consumed by the previous token's trailing-space range.
-                // Ranges are disjoint.
-                boolean atLineStart = before.trim().isEmpty();
-
-                deleteStart = atLineStart ? lineStart : annotStart;
+            if (!atLineEnd) {
+                // Case C: annotation shares its line with tokens that follow it
+                // (e.g. an inline annotation in a parameter list, or a leading
+                // annotation when siblings follow on the same line).
+                // Delete the annotation plus any immediately-following whitespace so
+                // the next token slides into place without a double-space.
+                deleteStart = annotStart;
                 deleteEnd = annotEnd;
-                // Eat one trailing space if one exists on the same line.
-                if (deleteEnd < lineEnd) {
-                    char c = source.charAt(deleteEnd);
-                    if (c == ' ' || c == '\t') {
-                        deleteEnd++;
+                while (deleteEnd < source.length()
+                        && (source.charAt(deleteEnd) == ' ' || source.charAt(deleteEnd) == '\t')) {
+                    deleteEnd++;
+                }
+            } else if (!before.trim().isEmpty()) {
+                // Case A: annotation is the last non-whitespace token on its line AND
+                // there are other non-whitespace tokens before it on the SAME line.
+                // Delete only the annotation (and any leading space absorbed by annotStart)
+                // up to but NOT including the \n, so the line break is preserved and the
+                // next line stays on its own line.
+                deleteStart = annotStart;
+                deleteEnd = lineEnd;   // stop before the \n — preserve the line break
+            } else {
+                // Case B: annotation is alone on its line (only whitespace before/after).
+                //
+                // ASTRewrite absorbs the preceding newline (backward) when ALL of:
+                //   - the declaring node is a field or type (not a method or parameter),
+                //   - this annotation is the last element in the modifiers list,
+                //   - the preceding line ends with non-whitespace content,
+                //   - no other annotation has been queued for deletion yet (sole removal).
+                //
+                // Otherwise absorb the following newline and next-line indent (forward).
+                int prevLineEnd = lineStart - 1; // offset of the '\n' before this line, or -1
+                boolean prevLineHasContent = false;
+                if (prevLineEnd >= 0) {
+                    // scan backward from \n to the start of the preceding line
+                    int scan = prevLineEnd - 1;
+                    while (scan >= 0 && source.charAt(scan) != '\n') {
+                        if (!Character.isWhitespace(source.charAt(scan))) {
+                            prevLineHasContent = true;
+                            break;
+                        }
+                        scan--;
                     }
+                    // If the preceding line is itself an annotation, do not absorb backward —
+                    // absorbing into another annotation's line would corrupt that annotation.
+                    if (prevLineHasContent) {
+                        int prevLineStart = prevLineEnd - 1;
+                        while (prevLineStart > 0 && source.charAt(prevLineStart - 1) != '\n') {
+                            prevLineStart--;
+                        }
+                        if (source.substring(prevLineStart, prevLineEnd).stripLeading().startsWith("@")) {
+                            prevLineHasContent = false;
+                        }
+                    }
+                }
+
+                // Backward is appropriate only when this is the sole annotation being
+                // removed in this call (i.e. no other delete has been queued yet).
+                // When multiple annotations are removed together, forward absorption
+                // for all of them produces adjacent ranges that merge cleanly.
+                boolean useBackward = (isField || isType)
+                        && i == children.size() - 1
+                        && prevLineHasContent
+                        && pendingDeletes.isEmpty();
+
+                if (useBackward) {
+                    // Absorb backward: delete '\n' + annotation (preceding line stays intact)
+                    deleteStart = prevLineEnd; // the '\n' ending the preceding line
+                    deleteEnd = annotEnd;
+                } else {
+                    // Absorb forward: delete annotation + '\n' + next-line indent
+                    deleteStart = annotStart;
+                    int nextLineStart = (lineEnd < source.length() && source.charAt(lineEnd) == '\n')
+                            ? lineEnd + 1 : lineEnd;
+                    int nextLineIndent = 0;
+                    while (nextLineStart + nextLineIndent < source.length()
+                            && (source.charAt(nextLineStart + nextLineIndent) == ' '
+                                    || source.charAt(nextLineStart + nextLineIndent) == '\t')) {
+                        nextLineIndent++;
+                    }
+                    deleteEnd = nextLineStart + nextLineIndent;
                 }
             }
 
-            editRoot.addChild(new DeleteEdit(deleteStart, deleteEnd - deleteStart));
+            pendingDeletes.add(new int[]{deleteStart, deleteEnd});
+        }
+
+        // Merge overlapping or adjacent DeleteEdits so that removing multiple
+        // consecutive annotations produces a single, non-overlapping edit.
+        pendingDeletes.sort((a, b) -> Integer.compare(a[0], b[0]));
+        int[] current = null;
+        for (int[] range : pendingDeletes) {
+            if (current == null) {
+                current = new int[]{range[0], range[1]};
+            } else if (range[0] <= current[1]) {
+                // overlapping or adjacent — extend
+                current[1] = Math.max(current[1], range[1]);
+            } else {
+                editRoot.addChild(new DeleteEdit(current[0], current[1] - current[0]));
+                current = new int[]{range[0], range[1]};
+            }
+        }
+        if (current != null) {
+            editRoot.addChild(new DeleteEdit(current[0], current[1] - current[0]));
         }
 
         // Rewrite imports if the import rewrite has accumulated changes.

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
@@ -16,6 +16,7 @@ package org.eclipse.lsp4jakarta.jdt.core.java.corrections.proposal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -29,10 +30,10 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
-import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.text.edits.DeleteEdit;
 import org.eclipse.text.edits.TextEdit;
@@ -46,6 +47,8 @@ import org.eclipse.text.edits.TextEdit;
  *
  */
 public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
+    private static final Logger LOGGER = Logger.getLogger(RemoveAnnotationProposal.class.getName());
+
     private final CompilationUnit fInvocationNode;
     private final IBinding fBinding;
 
@@ -74,10 +77,8 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
 
     @Override
     protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
-        // Call CUCorrectionProposal.addEdits() (empty default), not
-        // ASTRewriteCorrectionProposal.addEdits(), since we handle edits directly.
-        super.addEdits(document, editRoot);
-
+        // Do not call super.addEdits() — we handle all edits and import rewrites
+        // directly, bypassing the ASTRewrite machinery in the parent class.
         ASTNode declNode = this.declaringNode;
         ASTNode boundNode = fInvocationNode.findDeclaringNode(fBinding);
         CompilationUnit newRoot = fInvocationNode;
@@ -110,6 +111,9 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
         }
 
         String source = document.get();
+        // Detect the actual line delimiter used in this document (\n or \r\n).
+        String lineDelim = TextUtilities.getDefaultLineDelimiter(document);
+        char lineDelimEnd = lineDelim.charAt(lineDelim.length() - 1); // always '\n'
         List<int[]> pendingDeletes = new ArrayList<>();
 
         for (int i = 0; i < children.size(); i++) {
@@ -134,13 +138,13 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
 
             // Find the start of the line containing this annotation.
             int lineStart = annotStart;
-            while (lineStart > 0 && source.charAt(lineStart - 1) != '\n') {
+            while (lineStart > 0 && source.charAt(lineStart - 1) != lineDelimEnd) {
                 lineStart--;
             }
 
-            // Find the end of the line containing this annotation (exclusive of \n).
+            // Find the end of the line containing this annotation (exclusive of line delimiter).
             int lineEnd = annotEnd;
-            while (lineEnd < source.length() && source.charAt(lineEnd) != '\n') {
+            while (lineEnd < source.length() && source.charAt(lineEnd) != lineDelimEnd) {
                 lineEnd++;
             }
 
@@ -183,12 +187,12 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
                 //   - no other annotation has been queued for deletion yet (sole removal).
                 //
                 // Otherwise absorb the following newline and next-line indent (forward).
-                int prevLineEnd = lineStart - 1; // offset of the '\n' before this line, or -1
+                int prevLineEnd = lineStart - 1; // offset of the line delimiter before this line, or -1
                 boolean prevLineHasContent = false;
                 if (prevLineEnd >= 0) {
-                    // scan backward from \n to the start of the preceding line
+                    // scan backward from line delimiter to the start of the preceding line
                     int scan = prevLineEnd - 1;
-                    while (scan >= 0 && source.charAt(scan) != '\n') {
+                    while (scan >= 0 && source.charAt(scan) != lineDelimEnd) {
                         if (!Character.isWhitespace(source.charAt(scan))) {
                             prevLineHasContent = true;
                             break;
@@ -200,7 +204,7 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
                     // absorbing into a comment would produce confusing output.
                     if (prevLineHasContent) {
                         int prevLineStart = prevLineEnd - 1;
-                        while (prevLineStart > 0 && source.charAt(prevLineStart - 1) != '\n') {
+                        while (prevLineStart > 0 && source.charAt(prevLineStart - 1) != lineDelimEnd) {
                             prevLineStart--;
                         }
                         String prevLineContent = source.substring(prevLineStart, prevLineEnd).stripLeading();
@@ -227,9 +231,9 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
                     deleteStart = prevLineEnd; // the '\n' ending the preceding line
                     deleteEnd = annotEnd;
                 } else {
-                    // Absorb forward: delete annotation + '\n' + next-line indent
+                    // Absorb forward: delete annotation + line delimiter + next-line indent
                     deleteStart = annotStart;
-                    int nextLineStart = (lineEnd < source.length() && source.charAt(lineEnd) == '\n')
+                    int nextLineStart = (lineEnd < source.length() && source.charAt(lineEnd) == lineDelimEnd)
                             ? lineEnd + 1 : lineEnd;
                     int nextLineIndent = 0;
                     while (nextLineStart + nextLineIndent < source.length()
@@ -242,6 +246,11 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
             }
 
             pendingDeletes.add(new int[]{deleteStart, deleteEnd});
+        }
+
+        if (pendingDeletes.isEmpty()) {
+            LOGGER.warning("RemoveAnnotationProposal: no matching annotations found to remove for "
+                    + Arrays.toString(annotations) + " on node " + declaringNode.getClass().getSimpleName());
         }
 
         // Merge overlapping or adjacent DeleteEdits so that removing multiple
@@ -270,15 +279,6 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
                 editRoot.addChild(importEdit);
             }
         }
-    }
-
-    /**
-     * Not used — {@link #addEdits} handles everything directly to avoid
-     * ASTRewrite producing delete ranges that cross line boundaries.
-     */
-    @Override
-    protected ASTRewrite getRewrite() throws CoreException {
-        return null;
     }
 
     /**

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/java/corrections/proposal/RemoveAnnotationProposal.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -31,10 +30,11 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
-import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
-import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.text.edits.DeleteEdit;
+import org.eclipse.text.edits.TextEdit;
 
 /**
  *
@@ -61,7 +61,6 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
      * @param relevance
      * @param declaringNode - declaringNode covered node of diagnostic
      * @param annotations
-     *
      */
     public RemoveAnnotationProposal(String label, ICompilationUnit targetCU, CompilationUnit invocationNode,
                                     IBinding binding, int relevance, ASTNode declaringNode, String... annotations) {
@@ -73,7 +72,11 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
     }
 
     @Override
-    protected ASTRewrite getRewrite() throws CoreException {
+    protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
+        // Call CUCorrectionProposal.addEdits() (empty default), not
+        // ASTRewriteCorrectionProposal.addEdits(), since we handle edits directly.
+        super.addEdits(document, editRoot);
+
         ASTNode declNode = this.declaringNode;
         ASTNode boundNode = fInvocationNode.findDeclaringNode(fBinding);
         CompilationUnit newRoot = fInvocationNode;
@@ -89,45 +92,106 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
         boolean isType = declNode instanceof TypeDeclaration;
         boolean isParam = declNode instanceof SingleVariableDeclaration;
 
-        String[] annotations = getAnnotations();
+        if (!(isField || isMethod || isType || isParam)) {
+            return;
+        }
 
-        if (isField || isMethod || isType || isParam) {
-            AST ast = declNode.getAST();
-            ASTRewrite rewrite = ASTRewrite.create(ast);
+        @SuppressWarnings("unchecked")
+        List<? extends ASTNode> children;
+        if (isMethod) {
+            children = (List<? extends ASTNode>) declNode.getStructuralProperty(MethodDeclaration.MODIFIERS2_PROPERTY);
+        } else if (isType) {
+            children = (List<? extends ASTNode>) declNode.getStructuralProperty(TypeDeclaration.MODIFIERS2_PROPERTY);
+        } else if (isParam) {
+            children = (List<? extends ASTNode>) declNode.getStructuralProperty(SingleVariableDeclaration.MODIFIERS2_PROPERTY);
+        } else {
+            children = (List<? extends ASTNode>) declNode.getStructuralProperty(FieldDeclaration.MODIFIERS2_PROPERTY);
+        }
 
-            ImportRewriteContext importRewriteContext = new ContextSensitiveImportRewriteContext(declNode, imports);
+        String source = document.get();
 
-            // remove annotations in the removeAnnotations list
-            @SuppressWarnings("unchecked")
-            List<? extends ASTNode> children;
-            if (isMethod) {
-                children = (List<? extends ASTNode>) declNode.getStructuralProperty(MethodDeclaration.MODIFIERS2_PROPERTY);
-            } else if (isType) {
-                children = (List<? extends ASTNode>) declNode.getStructuralProperty(TypeDeclaration.MODIFIERS2_PROPERTY);
-            } else if (isParam) {
-                children = (List<? extends ASTNode>) declNode.getStructuralProperty(SingleVariableDeclaration.MODIFIERS2_PROPERTY);
-            } else {
-                children = (List<? extends ASTNode>) declNode.getStructuralProperty(FieldDeclaration.MODIFIERS2_PROPERTY);
+        for (ASTNode child : children) {
+            if (!(child instanceof Annotation)) {
+                continue;
             }
-            // find and save existing annotation, then remove it from ast
-            for (ASTNode child : children) {
-                if (child instanceof Annotation) {
-                    Annotation annotation = (Annotation) child;
-                    String matchingFqn = Arrays.stream(annotations).filter(fqn -> matchesAnnotation(fqn, annotation.getTypeName().toString())).findFirst().orElse(null);
-                    if (matchingFqn != null) {
-                        // Resolving fully qualified name from Annotation to fix issue #567
-                        ITypeBinding binding = annotation.resolveTypeBinding();
-                        if (binding.getQualifiedName().equals(matchingFqn)) {
-                            rewrite.remove(child, null);
-                        }
-                    }
+            Annotation annotation = (Annotation) child;
+            // Skip over annotations that don't match those requested to delete
+            String matchingFqn = Arrays.stream(getAnnotations()).filter(fqn -> matchesAnnotation(fqn, annotation.getTypeName().toString())).findFirst().orElse(null);
+            if (matchingFqn == null) {
+                continue;
+            }
+            ITypeBinding binding = annotation.resolveTypeBinding();
+            if (!binding.getQualifiedName().equals(matchingFqn)) {
+                continue;
+            }
 
+            // Finding line boundaries
+            int annotStart = child.getStartPosition(); // where @ starts
+            int annotEnd = annotStart + child.getLength(); // where annotation ends
+
+            // Find the start of the line containing this annotation.
+            int lineStart = annotStart;
+            while (lineStart > 0 && source.charAt(lineStart - 1) != '\n') {
+                lineStart--;
+            }
+
+            // Find the end of the line containing this annotation.
+            int lineEnd = annotEnd;
+            while (lineEnd < source.length() && source.charAt(lineEnd) != '\n') {
+                lineEnd++;
+            }
+
+            // Check whether the annotation is the only non-whitespace token on its line.
+            String before = source.substring(lineStart, annotStart);
+            String after = source.substring(annotEnd, lineEnd);
+            boolean aloneOnLine = before.trim().isEmpty() && after.trim().isEmpty();
+
+            int deleteStart;
+            int deleteEnd;
+
+            if (aloneOnLine) {
+                // Delete the entire line including its leading indentation and trailing newline,
+                // so no blank line is left behind.
+                deleteStart = lineStart;
+                deleteEnd = (lineEnd < source.length() && source.charAt(lineEnd) == '\n') ? lineEnd + 1 : lineEnd;
+            } else {
+                // The annotation shares its line with other tokens.
+                // Every annotation eats its trailing space (the separator after it).
+                // First token also eats leading indentation (deleteStart = lineStart).
+                // Later tokens start at annotStart since their preceding space was already
+                // consumed by the previous token's trailing-space range.
+                // Ranges are disjoint.
+                boolean atLineStart = before.trim().isEmpty();
+
+                deleteStart = atLineStart ? lineStart : annotStart;
+                deleteEnd = annotEnd;
+                // Eat one trailing space if one exists on the same line.
+                if (deleteEnd < lineEnd) {
+                    char c = source.charAt(deleteEnd);
+                    if (c == ' ' || c == '\t') {
+                        deleteEnd++;
+                    }
                 }
             }
 
-            return rewrite;
+            editRoot.addChild(new DeleteEdit(deleteStart, deleteEnd - deleteStart));
         }
 
+        // Rewrite imports if the import rewrite has accumulated changes.
+        if (imports != null) {
+            TextEdit importEdit = imports.rewriteImports(null);
+            if (importEdit != null && importEdit.hasChildren()) {
+                editRoot.addChild(importEdit);
+            }
+        }
+    }
+
+    /**
+     * Not used — {@link #addEdits} handles everything directly to avoid
+     * ASTRewrite producing delete ranges that cross line boundaries.
+     */
+    @Override
+    protected ASTRewrite getRewrite() throws CoreException {
         return null;
     }
 
@@ -157,14 +221,6 @@ public class RemoveAnnotationProposal extends ASTRewriteCorrectionProposal {
     protected String[] getAnnotations() {
         return this.annotations;
     }
-
-    /**
-     * Matches the Annotation
-     *
-     * @param fqn
-     * @param typeName
-     * @return
-     */
 
     private static boolean matchesAnnotation(String fqn, String typeName) {
         return fqn.equals(typeName) || fqn.endsWith("." + typeName);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/cdi/ManagedBeanTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/cdi/ManagedBeanTest.java
@@ -116,7 +116,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
         JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
         TextEdit te11 = te(35, 0, 36, 0, "");
         CodeAction ca11 = ca(uri, "Remove @RequestScoped", d1, te11);
-        TextEdit te12 = te(35, 14, 36, 14, "");
+        TextEdit te12 = te(36, 0, 37, 0, "");
         CodeAction ca12 = ca(uri, "Remove @SessionScoped", d1, te12);
         assertJavaCodeAction(codeActionParams1, IJDT_UTILS, ca11, ca12);
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/cdi/ManagedBeanTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/cdi/ManagedBeanTest.java
@@ -180,7 +180,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         // Assert for the diagnostic d1
         JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d1);
-        TextEdit te1 = te(11, 33, 12, 4, "");
+        TextEdit te1 = te(11, 33, 11, 43, "");
         TextEdit te2 = te(11, 14, 11, 33, "");
         CodeAction ca1 = ca(uri, "Remove @ApplicationScoped", d1, te2);
         CodeAction ca2 = ca(uri, "Remove @Dependent", d1, te1);
@@ -189,7 +189,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         // Assert for the diagnostic d2
         JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
-        TextEdit te3 = te(14, 33, 15, 4, "");
+        TextEdit te3 = te(14, 33, 14, 47, "");
         TextEdit te4 = te(14, 14, 14, 33, "");
         CodeAction ca3 = ca(uri, "Remove @ApplicationScoped", d2, te4);
         CodeAction ca4 = ca(uri, "Remove @RequestScoped", d2, te3);
@@ -198,7 +198,7 @@ public class ManagedBeanTest extends BaseJakartaTest {
 
         // Assert for the diagnostic d3
         JakartaJavaCodeActionParams codeActionParams3 = createCodeActionParams(uri, d3);
-        TextEdit te5 = te(9, 19, 10, 0, "");
+        TextEdit te5 = te(9, 19, 9, 33, "");
         TextEdit te6 = te(9, 0, 9, 19, "");
         CodeAction ca5 = ca(uri, "Remove @ApplicationScoped", d3, te6);
         CodeAction ca6 = ca(uri, "Remove @RequestScoped", d3, te5);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/persistence/JakartaPersistenceTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/persistence/JakartaPersistenceTest.java
@@ -71,7 +71,7 @@ public class JakartaPersistenceTest extends BaseJakartaTest {
 
         JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d2);
 
-        TextEdit te3 = te(14, 13, 15, 27, "");
+        TextEdit te3 = te(15, 4, 16, 4, "");
         TextEdit te4 = te(14, 4, 15, 4, "");
         CodeAction ca3 = ca(uri, "Remove @MapKeyClass", d2, te3);
         CodeAction ca4 = ca(uri, "Remove @MapKey", d2, te4);


### PR DESCRIPTION
Fixes #927 

# Problem
When applying "Remove @Annotation" on a class with two scope annotations on the same line, the line break between the annotation and public class was incorrectly eaten. When three annotations shared a line and two were removed simultaneously, the operation failed with Overlapping text edits.

# Fix
Replaced getRewrite() with an addEdits() override that computes precise DeleteEdit ranges from raw source text, guaranteed to never cross a line boundary or overlap with adjacent ranges.

# Test Cases Working: 

https://github.com/user-attachments/assets/ae9c9b1f-6cab-4aaf-9a1a-1fccb858a3b0

