### PR TITLE
Fixes #691 Diagnostics for Lifecycle callback interceptor methods declared in an interceptor class or superclass of an interceptor class must have one of the signatures void (InvocationContext) or Object (InvocationContext).

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/Constants.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/Constants.java
@@ -56,4 +56,10 @@ public class Constants {
     /* @InterceptorBinding */
     public static final String INTERCEPTOR_BINDING_FQ_NAME = "jakarta.interceptor.InterceptorBinding";
 
+    /* JDT return-type signature for void */
+    public static final String VOID_RETURN_TYPE = "V";
+
+    /* Fully qualified name of java.lang.Object */
+    public static final String JAVA_LANG_OBJECT = "java.lang.Object";
+
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode implements IJavaErrorCode {
     InvalidInterceptorMethodAnnotationOnStaticMethod,
     InvalidInterceptorNegativePriority,
     InvalidMultipleInterceptorMethodsOfSameType,
-    InvalidInterceptorMissingInterceptorBinding;
+    InvalidInterceptorMissingInterceptorBinding,
+    InvalidLifecycleCallbackInterceptorMethodSignature;
 
     /**
      * {@inheritDoc}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/InterceptorDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/InterceptorDiagnosticsParticipant.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
@@ -108,6 +109,9 @@ public class InterceptorDiagnosticsParticipant implements IJavaDiagnosticsPartic
                 for (IMethod method : type.getMethods()) {
                     // Validate interceptor method modifiers
                     validateInterceptorMethodModifiers(context, uri, diagnostics, type, method);
+
+                    // Validate lifecycle callback method signatures
+                    validateLifecycleCallbackMethodSignature(context, uri, diagnostics, type, method);
 
                     // Collect methods by annotation type for duplicate detection
                     List<String> interceptorAnnotations = getInterceptorMethodAnnotations(type, method);
@@ -331,6 +335,55 @@ public class InterceptorDiagnosticsParticipant implements IJavaDiagnosticsPartic
                                                              DiagnosticSeverity.Error));
                 }
             }
+        }
+    }
+
+    /**
+     * Validates that a lifecycle callback interceptor method has the required signature.
+     * According to Jakarta Interceptors 2.0 specification, lifecycle callback interceptor
+     * methods declared in an interceptor class or superclass must have one of the signatures:
+     * <ul>
+     * <li>{@code void <METHOD>(InvocationContext)}</li>
+     * <li>{@code Object <METHOD>(InvocationContext)}</li>
+     * </ul>
+     *
+     * @param context the diagnostics context
+     * @param uri the file URI
+     * @param diagnostics the list to add diagnostics to
+     * @param type the declaring type
+     * @param method the method to validate
+     * @throws JavaModelException if there's an error accessing the Java model
+     */
+    private void validateLifecycleCallbackMethodSignature(JavaDiagnosticsContext context, String uri,
+                                                          List<Diagnostic> diagnostics, IType type,
+                                                          IMethod method) throws JavaModelException {
+        // Only validate lifecycle callback methods
+        List<String> lifecycleAnnotations = DiagnosticUtils.getMatchedJavaElementNames(type,
+                                                                                       Stream.of(method.getAnnotations()).map(IAnnotation::getElementName).toArray(String[]::new),
+                                                                                       Constants.LIFECYCLE_CALLBACK_INTERCEPTOR_METHODS);
+        if (lifecycleAnnotations.isEmpty()) {
+            return;
+        }
+        boolean validSignature = false;
+        ILocalVariable[] params = method.getParameters();
+        if (params.length == 1) {
+            String paramSimpleName = DiagnosticUtils.getDataTypeName(params[0].getTypeSignature());
+            String resolvedParamType = ManagedBean.getFullyQualifiedClassName(type, paramSimpleName);
+            if (Constants.JAKARTA_INTERCEPTOR_INVOCATION_CONTEXT.equals(resolvedParamType)) {
+                String returnType = method.getReturnType();
+                boolean isVoid = Constants.VOID_RETURN_TYPE.equals(returnType);
+                boolean isObject = Constants.JAVA_LANG_OBJECT.equals(
+                                                                     ManagedBean.getFullyQualifiedClassName(type, DiagnosticUtils.getDataTypeName(returnType)));
+                validSignature = isVoid || isObject;
+            }
+        }
+        if (!validSignature) {
+            Range range = PositionUtils.toNameRange(method, context.getUtils());
+            diagnostics.add(context.createDiagnostic(uri,
+                                                     Messages.getMessage("InvalidLifecycleCallbackInterceptorMethodSignature"),
+                                                     range, Constants.DIAGNOSTIC_SOURCE,
+                                                     ErrorCode.InvalidLifecycleCallbackInterceptorMethodSignature,
+                                                     DiagnosticSeverity.Error));
         }
     }
 

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -299,6 +299,7 @@ InvalidInterceptorMethodAnnotationStaticMethod = {0} interceptor method must not
 InvalidInterceptorNegativePriority = Interceptor priority values must not be negative. Negative values are reserved for future use by the specification.
 InvalidMultipleInterceptorMethodsOfSameType = Only one method with {0} annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.
 InvalidInterceptorMissingInterceptorBinding = An interceptor declared using @Interceptor must specify at least one interceptor binding annotation.
+InvalidLifecycleCallbackInterceptorMethodSignature = Lifecycle callback interceptor methods declared in an interceptor class or its superclass must have one of the signatures: void <METHOD>(InvocationContext) or Object <METHOD>(InvocationContext).
 
 # SecurityDiagnosticsParticipant - Identity Store Definitions
 MissingApplicationScopedOnIdentityStoreDefinition = A class annotated with @{0} must be annotated with @ApplicationScoped.

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithInvalidSuperClass.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithInvalidSuperClass.java
@@ -1,0 +1,46 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Superclass of an interceptor class with invalid lifecycle callback method
+ * signatures. Validated when the subclass file is opened because both are
+ * declared in the same compilation unit.
+ */
+class InterceptorSuperClassBase {
+
+    // Invalid: wrong param type — @PreDestroy
+    @PreDestroy
+    public void preDestroyWrongParam(String name) throws Exception { }
+
+    // Invalid: wrong return type — @PostConstruct
+    @PostConstruct
+    public String postConstructInvalidReturn(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+    
+ // Invalid: wrong return type — @PostConstruct
+    @AroundConstruct
+    public String aroundConstructInvalidReturn(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+}
+
+/**
+ * Interceptor subclass — extends InterceptorSuperClassBase. Opening this file
+ * triggers validation of the superclass lifecycle callback methods above.
+ */
+@Monitored
+@Interceptor
+public class InterceptorSubClassWithInvalidSuperClass extends InterceptorSuperClassBase {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithValidSuperClass.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithValidSuperClass.java
@@ -1,0 +1,47 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Superclass of an interceptor class with valid lifecycle callback method
+ * signatures — no InvalidLifecycleCallbackInterceptorMethodSignature diagnostic
+ * must fire when the subclass file is opened.
+ */
+class InterceptorSuperClassValidBase {
+
+    // Makes this superclass interceptor-referenced so AnnotationDiagnosticsParticipant
+    // skips @PreDestroy/@PostConstruct validation on it
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    // Valid: void + InvocationContext — @PreDestroy
+    @PreDestroy
+    public void preDestroyValid(InvocationContext ctx) throws Exception {
+        ctx.proceed();
+    }
+
+    // Valid: Object + InvocationContext — @PostConstruct
+    @PostConstruct
+    public Object postConstructValid(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}
+
+/**
+ * Interceptor subclass — extends InterceptorSuperClassValidBase.
+ */
+@Monitored
+@Interceptor
+public class InterceptorSubClassWithValidSuperClass extends InterceptorSuperClassValidBase {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidLifecycleCallbackMethodSignature.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidLifecycleCallbackMethodSignature.java
@@ -1,0 +1,91 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Test resource for lifecycle callback interceptor method signature validation.
+ * Valid signatures: void <METHOD>(InvocationContext) or Object <METHOD>(InvocationContext).
+ */
+@Monitored
+@Interceptor
+public class InvalidLifecycleCallbackMethodSignature {
+
+    // ── @PreDestroy ──────────────────────────────────────────────────────────
+
+    // Invalid 1: void return + wrong parameter type (String)
+    @PreDestroy
+    public void preDestroyVoidWrongParam(String name) throws Exception { }
+
+    // Invalid 2: Object return + wrong parameter type (String)
+    @PreDestroy
+    public Object preDestroyObjectWrongParam(String name) throws Exception {
+        return name;
+    }
+
+    // Invalid 3: String return + InvocationContext parameter
+    @PreDestroy
+    public String preDestroyInvalidReturnType(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+
+    // ── @PostConstruct ───────────────────────────────────────────────────────
+
+    // Invalid 4: void return + wrong parameter type (String)
+    @PostConstruct
+    public void postConstructVoidWrongParam(String name) throws Exception { }
+
+    // Invalid 5: Object return + wrong parameter type (String)
+    @PostConstruct
+    public Object postConstructObjectWrongParam(String name) throws Exception {
+        return name;
+    }
+
+    // Invalid 6: String return + InvocationContext parameter
+    @PostConstruct
+    public String postConstructInvalidReturnType(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+
+    // ── @AroundConstruct ─────────────────────────────────────────────────────
+
+    // Invalid 7: void return + wrong parameter type (String)
+    @AroundConstruct
+    public void aroundConstructVoidWrongParam(String name) throws Exception { }
+
+    // Invalid 8: Object return + wrong parameter type (String)
+    @AroundConstruct
+    public Object aroundConstructObjectWrongParam(String name) throws Exception {
+        return name;
+    }
+
+    // Invalid 9: String return + InvocationContext parameter
+    @AroundConstruct
+    public String aroundConstructInvalidReturnType(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+
+    // ── Multiple parameters (invalid: spec requires exactly one InvocationContext) ──
+
+    // Invalid 10: two parameters — @PreDestroy
+    @PreDestroy
+    public void preDestroyMultipleParams(InvocationContext ctx, InvocationContext ctx2) throws Exception {
+        ctx.proceed();
+    }
+
+    // Invalid 11: two parameters — @PostConstruct
+    @PostConstruct
+    public void postConstructMultipleParams(InvocationContext ctx, InvocationContext ctx2) throws Exception {
+        ctx.proceed();
+    }
+
+    // Invalid 12: two parameters — @AroundConstruct
+    @AroundConstruct
+    public void aroundConstructMultipleParams(InvocationContext ctx, InvocationContext ctx2) throws Exception {
+        ctx.proceed();
+    }
+
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/NonLifecycleInterceptorAnnotations.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/NonLifecycleInterceptorAnnotations.java
@@ -1,0 +1,25 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.AroundTimeout;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Test resource: @AroundInvoke and @AroundTimeout methods with invalid-looking
+ * signatures must NOT trigger InvalidLifecycleCallbackInterceptorMethodSignature
+ * because those annotations are not lifecycle callback annotations.
+ */
+public class NonLifecycleInterceptorAnnotations {
+
+    // @AroundInvoke: wrong param type — must NOT trigger lifecycle-signature diagnostic
+    @AroundInvoke
+    public String aroundInvokeStringWrongParam(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+
+    // @AroundTimeout: wrong param type — must NOT trigger lifecycle-signature diagnostic
+    @AroundTimeout
+    public String aroundTimeoutStringWrongParam(InvocationContext ctx) throws Exception {
+        return (String) ctx.proceed();
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidLifecycleCallbackMethodSignature.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidLifecycleCallbackMethodSignature.java
@@ -1,0 +1,35 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+/**
+ * Test resource: lifecycle callback interceptor methods with valid signatures.
+ * All three lifecycle annotations use void <METHOD>(InvocationContext) or
+ * Object <METHOD>(InvocationContext) — no diagnostic must fire.
+ */
+@Monitored
+@Interceptor
+public class ValidLifecycleCallbackMethodSignature {
+
+    // Valid: void return + InvocationContext — @PreDestroy
+    @PreDestroy
+    public void preDestroyVoidValid(InvocationContext ctx) throws Exception {
+        ctx.proceed();
+    }
+
+    // Valid: Object return + InvocationContext — @PostConstruct
+    @PostConstruct
+    public Object postConstructObjectValid(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+
+    // Valid: void return + InvocationContext — @AroundConstruct
+    @AroundConstruct
+    public void aroundConstructVoidValid(InvocationContext ctx) throws Exception {
+        ctx.proceed();
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/interceptor/InterceptorTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/interceptor/InterceptorTest.java
@@ -727,4 +727,190 @@ public class InterceptorTest extends BaseJakartaTest {
         // Test that valid interceptor with @Monitored binding does NOT trigger diagnostic
         assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS);
     }
+
+    @Test
+    public void testInvalidLifecycleCallbackMethodSignatures() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+
+        IFile javaFile = javaProject.getProject().getFile(
+                                                          new Path("src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidLifecycleCallbackMethodSignature.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        String signatureMsg = "Lifecycle callback interceptor methods declared in an interceptor class or its superclass must have one of the signatures: void <METHOD>(InvocationContext) or Object <METHOD>(InvocationContext).";
+        String proceedMsg = "Interceptor methods must always call the InvocationContext.proceed method.";
+        String preDestroyDupMsg = "Only one method with @PreDestroy annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.";
+        String postConstructDupMsg = "Only one method with @PostConstruct annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.";
+        String aroundConstructDupMsg = "Only one method with @AroundConstruct annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.";
+
+        // ── @PreDestroy ──────────────────────────────────────────────────────
+        // Invalid 1 (first @PreDestroy — no duplicate diagnostic)
+        Diagnostic preDestroyVoidWrongParamSig = d(20, 16, 40, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic preDestroyVoidWrongParamProceed = d(20, 16, 40, proceedMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        // Invalid 2 (second @PreDestroy — duplicate)
+        Diagnostic preDestroyObjectWrongParamSig = d(24, 18, 44, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                     "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic preDestroyObjectWrongParamProceed = d(24, 18, 44, proceedMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+        Diagnostic preDestroyObjectWrongParamDup = d(24, 18, 44, preDestroyDupMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
+
+        // Invalid 3 (third @PreDestroy — duplicate)
+        Diagnostic preDestroyInvalidReturnTypeSig = d(30, 18, 45, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                      "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic preDestroyInvalidReturnTypeDup = d(30, 18, 45, preDestroyDupMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
+
+        // ── @PostConstruct ───────────────────────────────────────────────────
+        // Invalid 4 (first @PostConstruct — no duplicate diagnostic)
+        Diagnostic postConstructVoidWrongParamSig = d(38, 16, 43, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                      "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic postConstructVoidWrongParamProceed = d(38, 16, 43, proceedMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        // Invalid 5 (second @PostConstruct — duplicate)
+        Diagnostic postConstructObjectWrongParamSig = d(42, 18, 47, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                        "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic postConstructObjectWrongParamProceed = d(42, 18, 47, proceedMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+        Diagnostic postConstructObjectWrongParamDup = d(42, 18, 47, postConstructDupMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                        "InvalidMultipleInterceptorMethodsOfSameType");
+
+        // Invalid 6 (third @PostConstruct — duplicate)
+        Diagnostic postConstructInvalidReturnTypeSig = d(48, 18, 48, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                         "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic postConstructInvalidReturnTypeDup = d(48, 18, 48, postConstructDupMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                         "InvalidMultipleInterceptorMethodsOfSameType");
+
+        // ── @AroundConstruct ─────────────────────────────────────────────────
+        // Invalid 7 (first @AroundConstruct — no duplicate diagnostic)
+        Diagnostic aroundConstructVoidWrongParamSig = d(56, 16, 45, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                        "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic aroundConstructVoidWrongParamProceed = d(56, 16, 45, proceedMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        // Invalid 8 (second @AroundConstruct — duplicate)
+        Diagnostic aroundConstructObjectWrongParamSig = d(60, 18, 49, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                          "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic aroundConstructObjectWrongParamProceed = d(60, 18, 49, proceedMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+        Diagnostic aroundConstructObjectWrongParamDup = d(60, 18, 49, aroundConstructDupMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                          "InvalidMultipleInterceptorMethodsOfSameType");
+
+        // Invalid 9 (third @AroundConstruct — duplicate)
+        Diagnostic aroundConstructInvalidReturnTypeSig = d(66, 18, 50, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                           "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic aroundConstructInvalidReturnTypeDup = d(66, 18, 50, aroundConstructDupMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                           "InvalidMultipleInterceptorMethodsOfSameType");
+
+        // ── Multiple parameters ───────────────────────────────────────────────
+        // Invalid 10 (fourth @PreDestroy — duplicate, two InvocationContext params)
+        Diagnostic preDestroyMultipleParamsSig = d(74, 16, 40, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic preDestroyMultipleParamsDup = d(74, 16, 40, preDestroyDupMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
+
+        // Invalid 11 (fourth @PostConstruct — duplicate, two InvocationContext params)
+        Diagnostic postConstructMultipleParamsSig = d(80, 16, 43, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                      "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic postConstructMultipleParamsDup = d(80, 16, 43, postConstructDupMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                      "InvalidMultipleInterceptorMethodsOfSameType");
+
+        // Invalid 12 (fourth @AroundConstruct — duplicate, two InvocationContext params)
+        Diagnostic aroundConstructMultipleParamsSig = d(86, 16, 45, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                        "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic aroundConstructMultipleParamsDup = d(86, 16, 45, aroundConstructDupMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                        "InvalidMultipleInterceptorMethodsOfSameType");
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS,
+                              preDestroyVoidWrongParamSig, preDestroyVoidWrongParamProceed,
+                              preDestroyObjectWrongParamSig, preDestroyObjectWrongParamDup, preDestroyObjectWrongParamProceed,
+                              preDestroyInvalidReturnTypeSig, preDestroyInvalidReturnTypeDup,
+                              preDestroyMultipleParamsSig, preDestroyMultipleParamsDup,
+                              postConstructVoidWrongParamSig, postConstructVoidWrongParamProceed,
+                              postConstructObjectWrongParamSig, postConstructObjectWrongParamDup, postConstructObjectWrongParamProceed,
+                              postConstructInvalidReturnTypeSig, postConstructInvalidReturnTypeDup,
+                              postConstructMultipleParamsSig, postConstructMultipleParamsDup,
+                              aroundConstructVoidWrongParamSig, aroundConstructVoidWrongParamProceed,
+                              aroundConstructObjectWrongParamSig, aroundConstructObjectWrongParamDup, aroundConstructObjectWrongParamProceed,
+                              aroundConstructInvalidReturnTypeSig, aroundConstructInvalidReturnTypeDup,
+                              aroundConstructMultipleParamsSig, aroundConstructMultipleParamsDup);
+    }
+
+    @Test
+    public void testValidLifecycleCallbackMethodSignatures() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+
+        IFile javaFile = javaProject.getProject().getFile(
+                                                          new Path("src/main/java/io/openliberty/sample/jakarta/interceptor/ValidLifecycleCallbackMethodSignature.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // void/Object + InvocationContext on all three lifecycle annotations — no diagnostic expected
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS);
+    }
+
+    @Test
+    public void testNonLifecycleAnnotationsDoNotTriggerSignatureDiagnostic() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+
+        IFile javaFile = javaProject.getProject().getFile(
+                                                          new Path("src/main/java/io/openliberty/sample/jakarta/interceptor/NonLifecycleInterceptorAnnotations.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // @AroundInvoke and @AroundTimeout with invalid-looking signatures must NOT trigger
+        // InvalidLifecycleCallbackInterceptorMethodSignature — they are not lifecycle callbacks
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS);
+    }
+
+    @Test
+    public void testSuperClassWithInvalidLifecycleCallbackMethodSignatures() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+
+        // Open the subclass file — superclass InterceptorSuperClassBase is declared in the same
+        // file, so opening it triggers superclass lifecycle signature validation
+        IFile javaFile = javaProject.getProject().getFile(
+                                                          new Path("src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithInvalidSuperClass.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        String signatureMsg = "Lifecycle callback interceptor methods declared in an interceptor class or its superclass must have one of the signatures: void <METHOD>(InvocationContext) or Object <METHOD>(InvocationContext).";
+        String proceedMsg = "Interceptor methods must always call the InvocationContext.proceed method.";
+
+        // Superclass @AroundConstruct with String return — signature diagnostic (line 28)
+        Diagnostic superAroundConstructInvalidReturnSig = d(28, 18, 46, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                            "InvalidLifecycleCallbackInterceptorMethodSignature");
+
+        // Superclass @PostConstruct with String return — signature diagnostic (line 22)
+        Diagnostic superPostConstructInvalidReturnSig = d(22, 18, 44, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                          "InvalidLifecycleCallbackInterceptorMethodSignature");
+
+        // Superclass @PreDestroy with wrong param type — signature + proceed diagnostics (line 18)
+        Diagnostic superPreDestroyWrongParamSig = d(18, 16, 36, signatureMsg, DiagnosticSeverity.Error, "jakarta-interceptor",
+                                                    "InvalidLifecycleCallbackInterceptorMethodSignature");
+        Diagnostic superPreDestroyWrongParamProceed = d(18, 16, 36, proceedMsg, DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidInterceptorMethodsProceedMissing");
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS,
+                              superAroundConstructInvalidReturnSig,
+                              superPostConstructInvalidReturnSig,
+                              superPreDestroyWrongParamSig, superPreDestroyWrongParamProceed);
+    }
+
+    @Test
+    public void testSuperClassWithValidLifecycleCallbackMethodSignatures() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+
+        // Open the subclass file — superclass InterceptorSuperClassValidBase is declared in the
+        // same file with valid signatures, so no diagnostic must fire
+        IFile javaFile = javaProject.getProject().getFile(
+                                                          new Path("src/main/java/io/openliberty/sample/jakarta/interceptor/InterceptorSubClassWithValidSuperClass.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Valid lifecycle callback signatures in superclass — no diagnostic must fire
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS);
+    }
 }


### PR DESCRIPTION
Fixes #691 

This currently has restriction for superclass check because:
- [x] It requires a full workspace build/index to be valid — not guaranteed during live editing
- [x] It would make every keystroke trigger an expensive project-wide type hierarchy search