### PR TITLE
Fixes #698 Warning- Exceptions and initialization and/or cleanup operations should typically be handled in try/catch/finally blocks around the proceed method.

### DIFF
--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/ASTUtils.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/core/ASTUtils.java
@@ -17,8 +17,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -28,6 +26,7 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.TryStatement;
 
 public class ASTUtils {
 
@@ -115,30 +114,70 @@ public class ASTUtils {
      * @return boolean
      */
     public static boolean containsMethodInvocation(MethodDeclaration methodDecl, String targetMethod, String parentFQN) {
-        if (methodDecl == null || methodDecl.getBody() == null) {
+        return findMethodInvocation(methodDecl, targetMethod, parentFQN) != null;
+    }
+
+    /**
+     * Checks whether the given MethodDeclaration contains a call to the specified method
+     * on the specified parent type, and that call is enclosed within a try statement
+     * (i.e., inside a try/catch or try/finally block).
+     *
+     * @param methodDecl the method declaration to inspect
+     * @param targetMethod the method name to look for (e.g. "proceed")
+     * @param parentFQN the fully qualified name of the declaring class (e.g. "jakarta.interceptor.InvocationContext")
+     * @return {@code true} if the matching method invocation exists AND is inside a try statement;
+     *         {@code false} otherwise
+     */
+    public static boolean isProceedWrappedInTryCatch(MethodDeclaration methodDecl, String targetMethod, String parentFQN) {
+        MethodInvocation match = findMethodInvocation(methodDecl, targetMethod, parentFQN);
+        if (match == null) {
             return false;
         }
-        AtomicBoolean found = new AtomicBoolean(false);
+        ASTNode parent = match.getParent();
+        while (parent != null && parent != methodDecl) {
+            if (parent instanceof TryStatement) {
+                return true;
+            }
+            parent = parent.getParent();
+        }
+        return false;
+    }
+
+    /**
+     * Finds the first {@link MethodInvocation} within the given method declaration whose name
+     * matches {@code targetMethod} and whose declaring class matches {@code parentFQN}.
+     * Returns {@code null} if no such invocation exists or the method body is absent.
+     *
+     * @param methodDecl the method declaration to search
+     * @param targetMethod the method name to look for
+     * @param parentFQN the fully qualified name of the declaring class
+     * @return the first matching {@link MethodInvocation}, or {@code null}
+     */
+    private static MethodInvocation findMethodInvocation(MethodDeclaration methodDecl, String targetMethod, String parentFQN) {
+        if (methodDecl == null || methodDecl.getBody() == null) {
+            return null;
+        }
+        MethodInvocation[] result = new MethodInvocation[1];
         methodDecl.accept(new ASTVisitor() {
             @Override
             public boolean visit(MethodInvocation node) {
-                if (found.get())
-                    return false; // stop descending if found
+                if (result[0] != null) {
+                    return false; // already found, stop visiting
+                }
                 if (targetMethod.equals(node.getName().getIdentifier())) {
                     IMethodBinding binding = node.resolveMethodBinding();
                     if (binding != null) {
                         ITypeBinding declaringClass = binding.getDeclaringClass();
-                        if (declaringClass != null &&
-                            parentFQN.equals(declaringClass.getQualifiedName())) {
-                            found.set(true);
-                            return false; // stop visiting children of this node
+                        if (declaringClass != null && parentFQN.equals(declaringClass.getQualifiedName())) {
+                            result[0] = node;
+                            return false;
                         }
                     }
                 }
-                return true; // keep traversing nodes until found
+                return true;
             }
         });
-        return found.get();
+        return result[0];
     }
 
     /**

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/ErrorCode.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode implements IJavaErrorCode {
     InvalidInterceptorMethodAnnotationOnStaticMethod,
     InvalidInterceptorNegativePriority,
     InvalidMultipleInterceptorMethodsOfSameType,
-    InvalidInterceptorMissingInterceptorBinding;
+    InvalidInterceptorMissingInterceptorBinding,
+    InvalidInterceptorProceedNotInTryCatch;
 
     /**
      * {@inheritDoc}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/InterceptorDiagnosticsParticipant.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/java/org/eclipse/lsp4jakarta/jdt/internal/interceptor/InterceptorDiagnosticsParticipant.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.CoreException;
@@ -121,21 +120,52 @@ public class InterceptorDiagnosticsParticipant implements IJavaDiagnosticsPartic
             }
         }
         List<MethodDeclaration> allMethodDeclarations = ASTUtils.getMethodDeclarations(unit);
-        //Used to get the list of method declarations for interceptor methods that doesn't use proceed method
-        List<MethodDeclaration> invocationContextMethodInvocations = allMethodDeclarations.stream().filter(methodDecl -> {
+        List<MethodDeclaration> invocationContextMethodInvocations = new ArrayList<>();
+        List<MethodDeclaration> proceedNotInTryCatch = new ArrayList<>();
+        for (MethodDeclaration methodDecl : allMethodDeclarations) {
             try {
-                return isMatchedInvocationContextMethods(unit, methodDecl);
+                if (isMatchedInvocationContextMethods(unit, methodDecl)) {
+                    invocationContextMethodInvocations.add(methodDecl);
+                } else if (isInterceptorMethodWithUnwrappedProceed(unit, methodDecl)) {
+                    proceedNotInTryCatch.add(methodDecl);
+                }
             } catch (JavaModelException e) {
-                return false;
+                LOGGER.log(Level.WARNING, "Unable to validate interceptor method proceed usage", e);
             }
-        }).collect(Collectors.toList());
+        }
         for (MethodDeclaration m : invocationContextMethodInvocations) {
             Range range = JDTUtils.toRange(unit, m.getName().getStartPosition(), m.getName().getLength());
             diagnostics.add(context.createDiagnostic(uri, Messages.getMessage("InvalidInterceptorMethodsProceedMissing"),
                                                      range, Constants.DIAGNOSTIC_SOURCE, ErrorCode.InvalidInterceptorMethodsProceedMissing,
                                                      DiagnosticSeverity.Error));
         }
+        for (MethodDeclaration m : proceedNotInTryCatch) {
+            Range range = JDTUtils.toRange(unit, m.getName().getStartPosition(), m.getName().getLength());
+            diagnostics.add(context.createDiagnostic(uri, Messages.getMessage("InvalidInterceptorProceedNotInTryCatch"),
+                                                     range, Constants.DIAGNOSTIC_SOURCE, ErrorCode.InvalidInterceptorProceedNotInTryCatch,
+                                                     DiagnosticSeverity.Warning));
+        }
         return diagnostics;
+    }
+
+    /**
+     * Checks whether a method declaration is an interceptor method that calls {@code proceed()}
+     * but does NOT wrap that call in a try/catch/finally block.
+     *
+     * <p>According to the Jakarta Interceptors specification, exceptions and initialization
+     * and/or cleanup operations should typically be handled in try/catch/finally blocks
+     * around the proceed method.</p>
+     *
+     * @param unit the compilation unit
+     * @param methodDecl the method declaration to inspect
+     * @return {@code true} if the method is an interceptor method whose {@code proceed()} call
+     *         is not enclosed in a try statement; {@code false} otherwise
+     * @throws JavaModelException if there is an error accessing the Java model
+     */
+    private boolean isInterceptorMethodWithUnwrappedProceed(ICompilationUnit unit, MethodDeclaration methodDecl) throws JavaModelException {
+        return !isMatchedInvocationContextMethods(unit, methodDecl)
+               && ASTUtils.containsMethodInvocation(methodDecl, Constants.PROCEED, Constants.JAKARTA_INTERCEPTOR_INVOCATION_CONTEXT)
+               && !ASTUtils.isProceedWrappedInTryCatch(methodDecl, Constants.PROCEED, Constants.JAKARTA_INTERCEPTOR_INVOCATION_CONTEXT);
     }
 
     /**

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.core/src/main/resources/org/eclipse/lsp4jakarta/jdt/core/messages/messages.properties
@@ -301,6 +301,7 @@ InvalidInterceptorMethodAnnotationStaticMethod = {0} interceptor method must not
 InvalidInterceptorNegativePriority = Interceptor priority values must not be negative. Negative values are reserved for future use by the specification.
 InvalidMultipleInterceptorMethodsOfSameType = Only one method with {0} annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.
 InvalidInterceptorMissingInterceptorBinding = An interceptor declared using @Interceptor must specify at least one interceptor binding annotation.
+InvalidInterceptorProceedNotInTryCatch = Exceptions and initialization and/or cleanup operations should typically be handled in try/catch/finally blocks around the proceed method.
 
 # SecurityDiagnosticsParticipant - Identity Store Definitions
 MissingApplicationScopedOnIdentityStoreDefinition = A class annotated with @{0} must be annotated with @ApplicationScoped.

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptorProceedNotInTryCatch.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptorProceedNotInTryCatch.java
@@ -1,0 +1,52 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.AroundTimeout;
+import jakarta.interceptor.InvocationContext;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+/**
+ * Invalid: interceptor methods call proceed() but the call is not wrapped
+ * in a try/catch/finally block.
+ */
+public class InvalidInterceptorProceedNotInTryCatch {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return ctx.proceed(); // No try/catch/finally
+    }
+
+    @AroundConstruct
+    public Object aroundConstruct(InvocationContext ctx) throws Exception {
+        return ctx.proceed(); // No try/catch/finally
+    }
+
+    @AroundTimeout
+    public Object aroundTimeout(InvocationContext ctx) throws Exception {
+        return ctx.proceed(); // No try/catch/finally
+    }
+
+    @PostConstruct
+    public void postConstruct(InvocationContext ctx) throws Exception {
+        ctx.proceed(); // No try/catch/finally
+    }
+
+    @PreDestroy
+    public void preDestroy(InvocationContext ctx) throws Exception {
+        ctx.proceed(); // No try/catch/finally
+    }
+
+    // Corner case: proceed() is called outside the try block — should still warn
+    @AroundInvoke
+    public Object proceedOutsideTry(InvocationContext ctx) throws Exception {
+        Object result = ctx.proceed(); // outside the try — no protection
+        try {
+            System.out.println("logging");
+        } finally {
+            System.out.println("cleanup");
+        }
+        return result;
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidInterceptorOneMethodPerType.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidInterceptorOneMethodPerType.java
@@ -27,30 +27,50 @@ public class ValidInterceptorOneMethodPerType {
     // Valid: Only one @AroundInvoke method
     @AroundInvoke
     public Object log(InvocationContext ctx) throws Exception {
-        return ctx.proceed();
+        try {
+            return ctx.proceed();
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     // Valid: Only one @AroundTimeout method
     @AroundTimeout
     public Object timeout(InvocationContext ctx) throws Exception {
-        return ctx.proceed();
+        try {
+            return ctx.proceed();
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     // Valid: Only one @PostConstruct method
     @PostConstruct
     public void init(InvocationContext ctx) throws Exception {
-        ctx.proceed();
+        try {
+            ctx.proceed();
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     // Valid: Only one @PreDestroy method
     @PreDestroy
     public void destroy(InvocationContext ctx) throws Exception {
-        ctx.proceed();
+        try {
+            ctx.proceed();
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     // Valid: Only one @AroundConstruct method
     @AroundConstruct
     public void construct(InvocationContext ctx) throws Exception {
-        ctx.proceed();
+        try {
+            ctx.proceed();
+        } catch (Exception e) {
+            throw e;
+        }
     }
 }

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidInterceptorProceedInTryCatch.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidInterceptorProceedInTryCatch.java
@@ -1,0 +1,66 @@
+package io.openliberty.sample.jakarta.interceptor;
+
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.AroundTimeout;
+import jakarta.interceptor.InvocationContext;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+/**
+ * Valid: interceptor methods call proceed() and the call is wrapped
+ * in a try/catch/finally block.
+ */
+public class ValidInterceptorProceedInTryCatch {
+
+    @AroundConstruct
+    public Object aroundConstruct(InvocationContext ctx) throws Exception {
+        try {
+            return ctx.proceed();
+        } finally {
+            System.out.println("aroundConstruct completed");
+        }
+    }
+
+    @AroundTimeout
+    public Object aroundTimeout(InvocationContext ctx) throws Exception {
+        try {
+            return ctx.proceed();
+        } catch (Exception ex) {
+            throw ex;
+        }
+    }
+
+    @PostConstruct
+    public void postConstruct(InvocationContext ctx) throws Exception {
+        try {
+            ctx.proceed();
+        } finally {
+            System.out.println("postConstruct completed");
+        }
+    }
+
+    @PreDestroy
+    public void preDestroy(InvocationContext ctx) throws Exception {
+        try {
+            ctx.proceed();
+        } catch (Exception ex) {
+            throw ex;
+        }
+    }
+
+    // Corner case: a different proceed() (not InvocationContext) — should NOT warn
+    static class Workflow {
+        void proceed() { }
+    }
+
+    @AroundInvoke
+    public Object differentProceed(InvocationContext ctx) throws Exception {
+        new Workflow().proceed(); // not InvocationContext.proceed()
+        try {
+            return ctx.proceed();
+        } catch (Exception ex) {
+            throw ex;
+        }
+    }
+}

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidInterceptorWithBinding.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/projects/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/interceptor/ValidInterceptorWithBinding.java
@@ -16,8 +16,10 @@ public class ValidInterceptorWithBinding {
     
     @AroundInvoke
     public Object log(InvocationContext ctx) throws Exception {
-        Object result = ctx.proceed();
-        return result;
+        try {
+            return ctx.proceed();
+        } catch (Exception e) {
+            throw e;
+        }
     }
 }
-

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/cdi/InterceptorDecoratorDisposerTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/cdi/InterceptorDecoratorDisposerTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 public class InterceptorDecoratorDisposerTest extends BaseJakartaTest {
 
     protected static IJDTUtils IJDT_UTILS = JDTUtilsLSImpl.getInstance();
+    private static final String PROCEED_NOT_IN_TRY_CATCH_MSG = "Exceptions and initialization and/or cleanup operations should typically be handled in try/catch/finally blocks around the proceed method.";
 
     @Test
     public void interceptorWithDisposer() throws Exception {
@@ -52,12 +53,16 @@ public class InterceptorDecoratorDisposerTest extends BaseJakartaTest {
         JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
         diagnosticsParams.setUris(Arrays.asList(uri));
 
-        // Test expected diagnostic
+        // Test expected diagnostics
         Diagnostic disposerDiag = d(17, 16, 23,
                                     "Interceptors and Decorators cannot have methods with parameter(s) 'conn' annotated with @Disposes.",
                                     DiagnosticSeverity.Error, "jakarta-cdi", "InvalidInterceptorOrDecoratorWithDisposerMethod");
 
-        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, disposerDiag);
+        Diagnostic proceedNotInTryCatch = d(13, 18, 27,
+                                            PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                            DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, disposerDiag, proceedNotInTryCatch);
 
         // Test quickfix
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, disposerDiag);

--- a/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/interceptor/InterceptorTest.java
+++ b/jakarta.jdt/org.eclipse.lsp4jakarta.jdt.test/src/main/java/org/eclipse/lsp4jakarta/jdt/test/interceptor/InterceptorTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 
 public class InterceptorTest extends BaseJakartaTest {
     protected static IJDTUtils IJDT_UTILS = JDTUtilsLSImpl.getInstance();
+    private static final String PROCEED_NOT_IN_TRY_CATCH_MSG = "Exceptions and initialization and/or cleanup operations should typically be handled in try/catch/finally blocks around the proceed method.";
 
     @Test
     public void invalidInterceptorTest() throws Exception {
@@ -231,8 +232,20 @@ public class InterceptorTest extends BaseJakartaTest {
                                               "Only one method with @AroundInvoke annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.",
                                               DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
 
+        // InvalidInterceptorProceedNotInTryCatch warnings: logFinal (8,24,32), logStatic (16,25,34), logValid (21,18,26)
+        Diagnostic proceedNotInTryCatchFinal = d(8, 24, 32,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchStatic = d(16, 25, 34,
+                                                  PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                  DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchValid = d(21, 18, 26,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+
         assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, finalModifierDiagnostic, abstractModifierDiagnostic, duplicateAroundInvoke1,
-                              proceedDiagnostic, staticModifierDiagnostic, invalidAbstractClassDiagnostic, duplicateAroundInvoke2, duplicateAroundInvoke3);
+                              proceedDiagnostic, staticModifierDiagnostic, invalidAbstractClassDiagnostic, duplicateAroundInvoke2, duplicateAroundInvoke3,
+                              proceedNotInTryCatchFinal, proceedNotInTryCatchStatic, proceedNotInTryCatchValid);
 
         // Test code actions for final modifier
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, finalModifierDiagnostic);
@@ -321,9 +334,24 @@ public class InterceptorTest extends BaseJakartaTest {
                                                  "Only one method with @AroundConstruct annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.",
                                                  DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
 
+        // InvalidInterceptorProceedNotInTryCatch warnings: logFinal (8,24,32), logStatic (16,25,34), logMulipleModifiers (21,31,50), logValid (26,18,26)
+        Diagnostic proceedNotInTryCatchFinal = d(8, 24, 32,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchStatic = d(16, 25, 34,
+                                                  PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                  DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchMultiple = d(21, 31, 50,
+                                                    PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                    DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchValid = d(26, 18, 26,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+
         assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, finalModifierDiagnostic, abstractModifierDiagnostic, duplicateAroundConstruct1,
                               proceedDiagnostics, staticModifierDiagnostic, invalidAbstractClassDiagnostics, invalidMulipleModifierFinalDiagnostics,
-                              invalidMulipleModifierStaticDiagnostics, duplicateAroundConstruct2, duplicateAroundConstruct3, duplicateAroundConstruct4);
+                              invalidMulipleModifierStaticDiagnostics, duplicateAroundConstruct2, duplicateAroundConstruct3, duplicateAroundConstruct4,
+                              proceedNotInTryCatchFinal, proceedNotInTryCatchStatic, proceedNotInTryCatchMultiple, proceedNotInTryCatchValid);
 
         // Test code actions for final modifier
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, finalModifierDiagnostic);
@@ -417,9 +445,20 @@ public class InterceptorTest extends BaseJakartaTest {
                                                "Only one method with @AroundTimeout annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.",
                                                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
 
+        // InvalidInterceptorProceedNotInTryCatch warnings: logFinal (8,24,32), logStatic (16,25,34), logValid (21,18,26)
+        Diagnostic proceedNotInTryCatchFinal = d(8, 24, 32,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchStatic = d(16, 25, 34,
+                                                  PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                  DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchValid = d(21, 18, 26,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+
         assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, finalModifierDiagnostic, abstractModifierDiagnostic, duplicateAroundTimeout1, proceedDiagnostic,
-                              staticModifierDiagnostic,
-                              invalidAbstractClassDiagnostic, duplicateAroundTimeout2, duplicateAroundTimeout3);
+                              staticModifierDiagnostic, invalidAbstractClassDiagnostic, duplicateAroundTimeout2, duplicateAroundTimeout3,
+                              proceedNotInTryCatchFinal, proceedNotInTryCatchStatic, proceedNotInTryCatchValid);
 
         // Test code actions for final modifier
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, finalModifierDiagnostic);
@@ -495,9 +534,21 @@ public class InterceptorTest extends BaseJakartaTest {
                                                "Only one method with @PostConstruct annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.",
                                                DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
 
+        // InvalidInterceptorProceedNotInTryCatch warnings: logFinal (10,24,32), logStatic (18,25,34), logValid (23,18,26)
+        Diagnostic proceedNotInTryCatchFinal = d(10, 24, 32,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchStatic = d(18, 25, 34,
+                                                  PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                  DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchValid = d(23, 18, 26,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+
         assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, abstractClassDiagnostic, finalModifierDiagnostic,
                               abstractModifierDiagnostic, duplicatePostConstruct1, proceedDiagnostic, staticModifierDiagnostic,
-                              duplicatePostConstruct2, duplicatePostConstruct3);
+                              duplicatePostConstruct2, duplicatePostConstruct3,
+                              proceedNotInTryCatchFinal, proceedNotInTryCatchStatic, proceedNotInTryCatchValid);
 
         // Test code actions for final modifier
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, finalModifierDiagnostic);
@@ -573,9 +624,21 @@ public class InterceptorTest extends BaseJakartaTest {
                                             "Only one method with @PreDestroy annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.",
                                             DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
 
+        // InvalidInterceptorProceedNotInTryCatch warnings: logFinal (10,24,32), logStatic (18,25,34), logValid (23,18,26)
+        Diagnostic proceedNotInTryCatchFinal = d(10, 24, 32,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchStatic = d(18, 25, 34,
+                                                  PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                  DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic proceedNotInTryCatchValid = d(23, 18, 26,
+                                                 PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+
         assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, abstractClassDiagnostic, finalModifierDiagnostic,
                               abstractModifierDiagnostic, duplicatePreDestroy1, proceedDiagnostic, staticModifierDiagnostic,
-                              duplicatePreDestroy2, duplicatePreDestroy3);
+                              duplicatePreDestroy2, duplicatePreDestroy3,
+                              proceedNotInTryCatchFinal, proceedNotInTryCatchStatic, proceedNotInTryCatchValid);
 
         // Test code actions for final modifier
         JakartaJavaCodeActionParams codeActionParams = createCodeActionParams(uri, finalModifierDiagnostic);
@@ -672,9 +735,38 @@ public class InterceptorTest extends BaseJakartaTest {
                                                    "Only one method with @AroundInvoke annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.",
                                                    DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
 
+        // InvalidInterceptorProceedNotInTryCatch warnings — every method with unwrapped proceed()
+        Diagnostic log1UnwrappedProceed = d(28, 18, 22, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic log2UnwrappedProceed = d(33, 18, 22, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic log3UnwrappedProceed = d(38, 18, 22, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic timeout1UnwrappedProceed = d(44, 18, 26, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor",
+                                                "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic timeout2UnwrappedProceed = d(49, 18, 26, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor",
+                                                "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic init1UnwrappedProceed = d(55, 16, 21, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic init2UnwrappedProceed = d(60, 16, 21, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic destroy1UnwrappedProceed = d(66, 16, 24, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor",
+                                                "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic destroy2UnwrappedProceed = d(71, 16, 24, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor",
+                                                "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic construct1UnwrappedProceed = d(77, 16, 26, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor",
+                                                  "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic construct2UnwrappedProceed = d(82, 16, 26, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor",
+                                                  "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic nested1UnwrappedProceed = d(91, 22, 29, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor",
+                                               "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic nested2UnwrappedProceed = d(96, 22, 29, PROCEED_NOT_IN_TRY_CATCH_MSG, DiagnosticSeverity.Warning, "jakarta-interceptor",
+                                               "InvalidInterceptorProceedNotInTryCatch");
+
         assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, aroundInvokeDuplicate1, aroundInvokeDuplicate2,
                               aroundTimeoutDuplicate, postConstructDuplicate, preDestroyDuplicate,
-                              aroundConstructDuplicate, nestedAroundInvokeDuplicate);
+                              aroundConstructDuplicate, nestedAroundInvokeDuplicate,
+                              log1UnwrappedProceed, log2UnwrappedProceed, log3UnwrappedProceed,
+                              timeout1UnwrappedProceed, timeout2UnwrappedProceed,
+                              init1UnwrappedProceed, init2UnwrappedProceed,
+                              destroy1UnwrappedProceed, destroy2UnwrappedProceed,
+                              construct1UnwrappedProceed, construct2UnwrappedProceed,
+                              nested1UnwrappedProceed, nested2UnwrappedProceed);
     }
 
     @Test
@@ -710,7 +802,11 @@ public class InterceptorTest extends BaseJakartaTest {
                                                 "An interceptor declared using @Interceptor must specify at least one interceptor binding annotation.",
                                                 DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorMissingInterceptorBinding");
 
-        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, missingBindingDiagnostic);
+        Diagnostic proceedNotInTryCatch = d(16, 18, 21,
+                                            PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                            DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, missingBindingDiagnostic, proceedNotInTryCatch);
     }
 
     @Test
@@ -725,6 +821,62 @@ public class InterceptorTest extends BaseJakartaTest {
         diagnosticsParams.setUris(Arrays.asList(uri));
 
         // Test that valid interceptor with @Monitored binding does NOT trigger diagnostic
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS);
+    }
+
+    @Test
+    public void testInterceptorProceedNotInTryCatchTest() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+
+        IFile javaFile = javaProject.getProject().getFile(
+                                                          new Path("src/main/java/io/openliberty/sample/jakarta/interceptor/InvalidInterceptorProceedNotInTryCatch.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        Diagnostic aroundInvokeWarning = d(16, 18, 30,
+                                           PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                           DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic aroundConstructWarning = d(21, 18, 33,
+                                              PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                              DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic aroundTimeoutWarning = d(26, 18, 31,
+                                            PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                            DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic postConstructWarning = d(31, 16, 29,
+                                            PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                            DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        Diagnostic preDestroyWarning = d(36, 16, 26,
+                                         PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                         DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+
+        // Corner case: proceed() called outside the try block — should still warn
+        Diagnostic proceedOutsideTryWarning = d(42, 18, 35,
+                                                PROCEED_NOT_IN_TRY_CATCH_MSG,
+                                                DiagnosticSeverity.Warning, "jakarta-interceptor", "InvalidInterceptorProceedNotInTryCatch");
+        // proceedOutsideTry is a second @AroundInvoke method — duplicate annotation diagnostic also fires
+        Diagnostic duplicateAroundInvoke = d(42, 18, 35,
+                                             "Only one method with @AroundInvoke annotation is allowed per class. Multiple methods with the same interceptor annotation type are not permitted.",
+                                             DiagnosticSeverity.Error, "jakarta-interceptor", "InvalidMultipleInterceptorMethodsOfSameType");
+
+        assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS, aroundInvokeWarning, aroundConstructWarning,
+                              aroundTimeoutWarning, postConstructWarning, preDestroyWarning, duplicateAroundInvoke,
+                              proceedOutsideTryWarning);
+    }
+
+    @Test
+    public void testValidInterceptorProceedInTryCatchTest() throws Exception {
+        IJavaProject javaProject = loadJavaProject("jakarta-sample", "");
+
+        IFile javaFile = javaProject.getProject().getFile(
+                                                          new Path("src/main/java/io/openliberty/sample/jakarta/interceptor/ValidInterceptorProceedInTryCatch.java"));
+        String uri = javaFile.getLocation().toFile().toURI().toString();
+
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // All interceptor methods use proceed() inside try/catch/finally — no warnings expected
         assertJavaDiagnostics(diagnosticsParams, IJDT_UTILS);
     }
 }


### PR DESCRIPTION
Fixes #698 